### PR TITLE
Fix Pick color button size

### DIFF
--- a/app/views/readings/_form.html.erb
+++ b/app/views/readings/_form.html.erb
@@ -14,7 +14,7 @@
   <%= f.label :color, class: 'control-label' %><br>
   <div class="input-append" id="color_div">
     <%= f.text_field :color, class: 'form-control' %>
-    <input type="button" class="btn btn-info" style="padding: 5px" id="pickcolor_button" value="Pick color"></input>
+    <input type="button" class="btn btn-info" style="height:30px" id="pickcolor_button" value="Pick color"></input>
   </div>
 </div>
 


### PR DESCRIPTION
Now it matches the field height, instead of being a bit smaller. Not the best solution, but it works.

[Original](http://i.imgur.com/2YcBic0)
[Fixed](http://i.imgur.com/nk4ZzXZ)

Not really related to LabXP though, I am just fixing this because this is bugging me a lot ;) .
