### PR TITLE
Fixed Module Tree acceptance tests that was failling randomly

### DIFF
--- a/features/repository/show/modules_tree.feature
+++ b/features/repository/show/modules_tree.feature
@@ -15,6 +15,8 @@ Feature: Repository modules tree
     And I ask for the last ready processing of the given repository
     And I ask for the module result of the given processing
     When I visit the repository show page
+    And I click the "Modules Tree" h3
+    And I wait for "5" seconds
     Then I should see the given module result
 
   @kalibro_restart @kalibro_processor_restart @javascript


### PR DESCRIPTION
This should minimize Travis errors
