### PR TITLE
 Fixes timeout in bundle install

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,9 +36,8 @@ gem 'kalibro_gatekeeper_client', "~> 0.3.1"
 # PostgreSQL integration
 gem "pg", "~> 0.17.0"
 
-# Twitter Bootstrap for layout
-gem 'twitter-bootstrap-rails', :git => 'git://github.com/seyhunak/twitter-bootstrap-rails.git', :ref => '95de3b0' #Fixed the ref so it does not update accidentaly and breaks
-
+# Twitter Bootstrap for layout'
+gem 'twitter-bootstrap-rails', :git => 'https://github.com/seyhunak/twitter-bootstrap-rails.git', :ref => '95de3b0'
 # Chart generation
 gem "chart-js-rails", "~> 0.0.6"
 


### PR DESCRIPTION
When we try to make a bundle install
The command crashed when trying to download the gem 'twitter-bootstrap-rails "

Gemfile in the master branch of prezento was

gem 'twitter-bootstrap-rails',: git => 'git: //github.com/seyhunak/twitter-bootstrap-rails.git',: ref => '95de3b0'

And we received timeout.

I changed to:

gem 'twitter-bootstrap-rails',: git => 'https://github.com/seyhunak/twitter-bootstrap-rails.git',: ref => '95de3b0'

And it worked correctly.
