### PR TITLE
Ignore exceptions produced by crawlers

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -100,6 +100,7 @@ Rails.application.configure do
 
   # Exception Notification
   config.middleware.use ExceptionNotification::Rack,
+  :ignore_crawlers => %w{Googlebot bingbot SeznamBot Baiduspider},
   :email => {
     :email_prefix => "[Prezento Error] ",
     :sender_address => %{"mezurometrics" <mezurometrics@gmail.com>},


### PR DESCRIPTION
This should reduce drastically the amount of exception emails received on mezuro-core list
