### PR TITLE
Source tree sorted

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,7 +149,7 @@ GEM
     jquery-ui-rails (5.0.3)
       railties (>= 3.2.16)
     json (1.8.2)
-    kalibro_client (0.0.3)
+    kalibro_client (0.1.0)
       activesupport (>= 2.2.1)
       faraday_middleware (~> 0.9.0)
     konacha (3.3.0)

--- a/app/helpers/kalibro_modules_helper.rb
+++ b/app/helpers/kalibro_modules_helper.rb
@@ -1,7 +1,11 @@
 module KalibroModulesHelper
   def sort_by_granularity_and_name(module_results)
-    module_results.sort do |a,b|
-      (a.kalibro_module.granularity == b.kalibro_module.granularity) ? a.kalibro_module.name <=> b.kalibro_module.name : -a.kalibro_module.granularity.length <=> -b.kalibro_module.granularity.length
+    module_results.sort! do |a,b|
+      if (a.kalibro_module.granularity == b.kalibro_module.granularity)
+        a.kalibro_module.name <=> b.kalibro_module.name
+      else
+        (KalibroClient::Entities::Miscellaneous::Granularity.new(b.kalibro_module.granularity.to_sym) <=> KalibroClient::Entities::Miscellaneous::Granularity.new(a.kalibro_module.granularity.to_sym))
+      end
     end
   end
 end

--- a/app/helpers/kalibro_modules_helper.rb
+++ b/app/helpers/kalibro_modules_helper.rb
@@ -1,0 +1,7 @@
+module KalibroModulesHelper
+  def sort_by_granularity_and_name(module_results)
+    module_results.sort do |a,b|
+      (a.kalibro_module.granularity == b.kalibro_module.granularity) ? a.kalibro_module.name <=> b.kalibro_module.name : -a.kalibro_module.granularity.length <=> -b.kalibro_module.granularity.length
+    end
+  end
+end

--- a/app/views/modules/_module_tree.html.erb
+++ b/app/views/modules/_module_tree.html.erb
@@ -15,7 +15,9 @@
 <% end %>
 
 <% cache("#{@root_module_result.id}_tree") do %>
-  <% children = @root_module_result.children %>
+  <% children = @root_module_result.children.sort do %>
+      <% |a,b| (a.module.granularity == b.module.granularity) ? a.module.name <=> b.module.name : -a.module.granularity.length <=> -b.module.granularity.length %>
+  <% end %>
   <% unless children.empty? %>
     <table class="table table-hover">
       <thead>

--- a/app/views/modules/_module_tree.html.erb
+++ b/app/views/modules/_module_tree.html.erb
@@ -15,9 +15,7 @@
 <% end %>
 
 <% cache("#{@root_module_result.id}_tree") do %>
-  <% children = @root_module_result.children.sort do %>
-      <% |a,b| (a.module.granularity == b.module.granularity) ? a.module.name <=> b.module.name : -a.module.granularity.length <=> -b.module.granularity.length %>
-  <% end %>
+  <% children = sort_by_granularity_and_name(@root_module_result.children) %>
   <% unless children.empty? %>
     <table class="table table-hover">
       <thead>

--- a/spec/factories/kalibro_modules.rb
+++ b/spec/factories/kalibro_modules.rb
@@ -1,6 +1,17 @@
 FactoryGirl.define do
   factory :kalibro_module, class: KalibroClient::Entities::Processor::KalibroModule do
     name 'Qt-Calculator'
-    granlrty 'APPLICATION'
+    granlrty 'SOFTWARE'
+
+    trait :package do
+      granlrty 'PACKAGE'
+    end
+
+    trait :class do
+      granlrty 'CLASS'
+    end
+
+    factory :kalibro_module_package, traits: [:package]
+    factory :kalibro_module_class, traits: [:class]
   end
 end

--- a/spec/helpers/kalibro_module_helper_spec.rb
+++ b/spec/helpers/kalibro_module_helper_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+describe KalibroModulesHelper, :type => :helper do
+  describe 'sort_by_granularity_and_name' do
+    let(:package) { FactoryGirl.build(:module_result, kalibro_module: FactoryGirl.build(:kalibro_module_package)) }
+    let(:class_a) { FactoryGirl.build(:module_result, kalibro_module: FactoryGirl.build(:kalibro_module_class, name: 'a')) }
+    let(:class_b) { FactoryGirl.build(:module_result, kalibro_module: FactoryGirl.build(:kalibro_module_class, name: 'b')) }
+
+    it 'is expected to order the ModuleResults by the Granularity first and then the KalibroModule name' do
+      unordered_modules = [class_b, package, class_a]
+      expect(helper.sort_by_granularity_and_name(unordered_modules)).to eq([package, class_a, class_b])
+    end
+  end
+end


### PR DESCRIPTION
Greater granularities are listed on top of smaller ones. Equal granularities are ordered by their names.

Just like Nautilus sorts your files and folders.

This closes: https://github.com/mezuro/prezento/issues/90