### PR TITLE
Fixes the user edition form

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -9,7 +9,7 @@
       <div class="form-row">
         <div class="field-container">
           <%= f.label :name, class: 'control-label' %><br />
-          <%= f.email_field :name, :autofocus => true, class: 'text-field form-control' %>
+          <%= f.text_field :name, :autofocus => true, class: 'text-field form-control' %>
         </div>
         <div class="help-container">
           <p>

--- a/features/users/user_update.feature
+++ b/features/users/user_update.feature
@@ -3,6 +3,7 @@ Feature: User update
   As a regular user
   I want to have an edit page
 
+  @javascript
   Scenario: with current password
     Given I am a regular user
     And I am signed in


### PR DESCRIPTION
Probably it got broken after the translations and the acceptance test was
passing due to the dependency of javascript.

The acceptance test was fixed and the form has now the right field type.