### PR TITLE
Fix wrong association to Project in ProjectAttributes

### DIFF
--- a/app/models/project_attributes.rb
+++ b/app/models/project_attributes.rb
@@ -1,7 +1,6 @@
 class ProjectAttributes < ActiveRecord::Base
   belongs_to :user
-  belongs_to :project
-
+  
   def project
     Project.find(self.project_id)
   end

--- a/spec/models/project_attributes_spec.rb
+++ b/spec/models/project_attributes_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 RSpec.describe ProjectAttributes, type: :model do
   describe 'associations' do
     it { is_expected.to belong_to(:user) }
-    it { is_expected.to belong_to(:project) }
   end
 
   describe 'methods' do


### PR DESCRIPTION
It doesn't work since Project is an entity from KalibroClient, not a
normal ActiveRecord model.