### PR TITLE
Fixed and refactored graphic for Metric Results

### DIFF
--- a/app/assets/javascripts/module/graphic.js.coffee
+++ b/app/assets/javascripts/module/graphic.js.coffee
@@ -1,7 +1,11 @@
 class Module.Graphic
   constructor: (@container, @metric_name, @module_id) ->
-    $('tr#'+@container).slideToggle('slow')
-    this.load()
+    drawer = $('tr#'+@container)
+    if drawer.is(":hidden")
+      drawer.slideDown('slow')
+      this.load()
+    else
+      drawer.slideUp('slow')
 
   load: ->
     $.post '/modules/' + @module_id + '/metric_history',
@@ -11,7 +15,13 @@ class Module.Graphic
           }
 
   @display: (dates, values, container) ->
-    opts = {bezierCurve: false}
+    canvas = $('canvas#'+container).get(0)
+
+    opts = {
+      bezierCurve: false,
+      responsive: true,
+      maintainAspectRatio: false
+    }
 
     data = {
       labels : dates,
@@ -26,4 +36,8 @@ class Module.Graphic
       ]
     }
 
-    graphic = new Chart($('canvas#'+container).get(0).getContext("2d")).Line(data, opts)
+    if canvas.hasOwnProperty("chart") && canvas.chart != null
+      canvas.chart.destroy()
+      canvas.chart = null
+
+    canvas.chart = new Chart(canvas.getContext("2d")).Line(data, opts)

--- a/app/assets/stylesheets/boilerplate/graphic.css
+++ b/app/assets/stylesheets/boilerplate/graphic.css
@@ -1,3 +1,0 @@
-div.graphic_container {
-  text-align: center;
-}

--- a/app/assets/stylesheets/module_results.css
+++ b/app/assets/stylesheets/module_results.css
@@ -1,0 +1,13 @@
+table.metric_results {
+    table-layout: fixed;
+}
+
+.metric_results div.graphic_container {
+    width: 100%;
+    max-height: 20em;
+}
+
+.metric_results div.graphic_container > canvas {
+    width: 100%;
+    height: 100%;
+}

--- a/app/views/modules/_metric_result.html.erb
+++ b/app/views/modules/_metric_result.html.erb
@@ -17,7 +17,6 @@
     <td colspan="4">
       <span id="loader_container<%= metric_result.id %>"><%= image_tag 'loader.gif' %> <%= t('loading_data') %></span>
       <canvas id="container<%= metric_result.id %>" class="graphic_container" style="display: none"></canvas>
-      <span id="container<%= metric_result.id %>" style="display: none"><%= t('only_point_printed_chart') %></span>
     </td>
   </tr>
 <% end %>

--- a/app/views/modules/_metric_results.html.erb
+++ b/app/views/modules/_metric_results.html.erb
@@ -1,9 +1,11 @@
 <table class="table table-hover metric_results">
   <thead>
-    <th><%= t('activemodel.attributes.metric_result.metric') %></th>
-    <th><%= t('activemodel.attributes.metric_result.value') %></th>
-    <th><%= t('activemodel.attributes.metric_result.weight') %></th>
-    <th><%= t('activemodel.attributes.metric_result.threshold') %></th>
+    <tr>
+      <th><%= t('activemodel.attributes.metric_result.metric') %></th>
+      <th><%= t('activemodel.attributes.metric_result.value') %></th>
+      <th><%= t('activemodel.attributes.metric_result.weight') %></th>
+      <th><%= t('activemodel.attributes.metric_result.threshold') %></th>
+    </tr>
   </thead>
 
   <tbody>

--- a/app/views/modules/_metric_results.html.erb
+++ b/app/views/modules/_metric_results.html.erb
@@ -1,4 +1,4 @@
-<table class="table table-hover">
+<table class="table table-hover metric_results">
   <thead>
     <th><%= t('activemodel.attributes.metric_result.metric') %></th>
     <th><%= t('activemodel.attributes.metric_result.value') %></th>

--- a/app/views/modules/metric_history.js.erb
+++ b/app/views/modules/metric_history.js.erb
@@ -10,11 +10,6 @@
   <% end %>
 
   $("#loader_<%= @container %>").hide();
-  if (dates.length > 1) {
-  	$("canvas#<%= @container %>").show();
-  	Module.Graphic.display(dates, values, '<%= @container %>');
-  }
-  else {
-  	$('span#<%= @container %>').show();
-  }
+  $("canvas#<%= @container %>").show();
+  Module.Graphic.display(dates, values, '<%= @container %>');
 <% end %>


### PR DESCRIPTION
Fixed graphic for Metric Results not displaying correctly

The graphic for Metric results previously did not have a set size.
Changed it so that it fills the whole space available, and made it
responsive to window resizing. That broke some particular cases of
histories with few changes and number of points that wasn't very small.

In addition, made the graphic display a single point instead of an
unhelpful messa