### PR TITLE
Attempt to fix Konacha test hangs on Travis by changing web server

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,7 +77,10 @@ group :test do
   gem 'mocha', require: 'mocha/api'
 
   # Test coverage report
-  gem "codeclimate-test-reporter", require: nil
+  gem 'codeclimate-test-reporter', require: nil
+
+  # For Konacha
+  gem 'thin'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,7 @@ GEM
       mime-types (>= 1.16, < 3)
       nokogiri (~> 1.5)
       rails (>= 3, < 5)
+    daemons (1.2.3)
     dalli (2.7.4)
     database_cleaner (1.4.1)
     debug_inspector (0.0.2)
@@ -120,6 +121,7 @@ GEM
     domain_name (0.5.24)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
+    eventmachine (1.0.7)
     exception_notification (4.1.1)
       actionmailer (>= 3.0.4)
       activesupport (>= 3.0.4)
@@ -293,6 +295,10 @@ GEM
     therubyracer (0.12.2)
       libv8 (~> 3.16.14.0)
       ref
+    thin (1.6.3)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0)
+      rack (~> 1.0)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (1.4.1)
@@ -364,6 +370,7 @@ DEPENDENCIES
   sprockets
   sqlite3
   therubyracer
+  thin
   turbolinks
   twitter-bootstrap-rails!
   uglifier (>= 1.3.0)

--- a/config/initializers/konacha.rb
+++ b/config/initializers/konacha.rb
@@ -1,8 +1,32 @@
-Konacha.configure do |config|
-  require 'capybara/poltergeist'
+if defined?(Konacha)
+  Konacha.configure do |config|
+    require 'capybara/poltergeist'
 
-  config.spec_dir     = "spec/javascripts"
-  config.spec_matcher = /_spec\.|_test\./
-  config.stylesheets  = %w(application)
-  config.driver = :poltergeist
-end if defined?(Konacha)
+    config.spec_dir     = "spec/javascripts"
+    config.spec_matcher = /_spec\.|_test\./
+    config.stylesheets  = %w(application)
+    config.driver = :poltergeist
+  end
+
+  # Use thin to run Konacha tests. This is needed because the tests hang frequently in Travis using the default (WEBRick)
+  # We can't just do 'Capybara.server' in the configure block because it will also apply to anything else run by
+  # Capybara. So instead, override the Konacha.run method to change the server, and restore it after completion.
+  module Konacha
+    class << self
+      old_run = instance_method(:run)
+
+      define_method(:run) do
+        prev_server = Capybara.server
+        begin
+          Capybara.server do |app, port|
+            require 'rack/handler/thin'
+            Rack::Handler::Thin.run(app, :Port => port)
+          end
+          old_run.bind(self).call
+        ensure
+          Capybara.server(&prev_server)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Use Thin when running Konacha tests, as recommended in
https://github.com/jfirebaugh/konacha/issues/146.
Hopefully it will make Travis stop exploding.