### PR TITLE
Fix missing translation on processing information when a date is chosen

### DIFF
--- a/app/views/repositories/show.html.erb
+++ b/app/views/repositories/show.html.erb
@@ -47,7 +47,7 @@
     <%= select_tag(:month, options_for_select(month_options), :style => "width:55px; margin-top:5px") %>
     <%= label_tag :year, t("year") %>:
     <%= select_tag(:year, options_for_select(year_options), :style => "width:70px; margin-top:5px") %>
-    <%= submit_tag(t('search'), class: 'btn btn-info', style: 'margin-bottom:5px', onClick: "Repository.State.set_loader('#{image_tag 'loader.gif'} Loading data. Please, wait.')") %>
+    <%= submit_tag(t('search'), class: 'btn btn-info', style: 'margin-bottom:5px', onClick: "Repository.State.set_loader('#{image_tag 'loader.gif'} #{j(t('repository.show.loading'))}')") %>
   </p>
 <% end %>
 


### PR DESCRIPTION
The button for searching for a processing result set by date manually
sets the HTML for the loading message. It was not using the correct
translation for the message. Fix that.