### PR TITLE
sqlite3 is not necessary under production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,6 @@ source 'https://rubygems.org'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.4'
 
-# Use sqlite3 as the database for Active Record
-gem 'sqlite3'
-
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0.0'
 
@@ -119,6 +116,9 @@ group :development, :test do
 
   # Mocks and stubs for javascript tests
   gem 'sinon-rails'
+
+  # Use sqlite3 as the database for Active Record
+  gem 'sqlite3'
 end
 
 # Acceptance tests


### PR DESCRIPTION
Moved the gem dependency just for development and test environments.