### PR TITLE
Fixes module tree ordering with FUNCTION granularity

### DIFF
--- a/app/helpers/kalibro_modules_helper.rb
+++ b/app/helpers/kalibro_modules_helper.rb
@@ -1,10 +1,23 @@
 module KalibroModulesHelper
+  # The comparison between FUNCTION and CLASS or METHOD does not make sense for kalibro.
+  # Still, we want to sort the kalibro modules to present it to the user.
+  # So, we define that FUNCTION are smaller than all the other granularities.
+  class ComparableGranularity < KalibroClient::Entities::Miscellaneous::Granularity
+    def <=>(other)
+      response = super(other)
+      if response.nil?
+        response = self.type == :FUNCTION ? -1 : 1
+      end
+      response
+    end
+  end
+
   def sort_by_granularity_and_name(module_results)
     module_results.sort! do |a,b|
       if (a.kalibro_module.granularity == b.kalibro_module.granularity)
         a.kalibro_module.name <=> b.kalibro_module.name
       else
-        (KalibroClient::Entities::Miscellaneous::Granularity.new(b.kalibro_module.granularity.to_sym) <=> KalibroClient::Entities::Miscellaneous::Granularity.new(a.kalibro_module.granularity.to_sym))
+        (ComparableGranularity.new(b.kalibro_module.granularity.to_sym) <=> ComparableGranularity.new(a.kalibro_module.granularity.to_sym))
       end
     end
   end

--- a/spec/factories/kalibro_modules.rb
+++ b/spec/factories/kalibro_modules.rb
@@ -11,7 +11,17 @@ FactoryGirl.define do
       granlrty 'CLASS'
     end
 
+    trait :function do
+      granlrty 'FUNCTION'
+    end
+
+    trait :method do
+      granlrty 'METHOD'
+    end
+
     factory :kalibro_module_package, traits: [:package]
     factory :kalibro_module_class, traits: [:class]
+    factory :kalibro_module_function, traits: [:function]
+    factory :kalibro_module_method, traits: [:method]
   end
 end

--- a/spec/helpers/kalibro_module_helper_spec.rb
+++ b/spec/helpers/kalibro_module_helper_spec.rb
@@ -3,12 +3,29 @@ require 'rails_helper'
 describe KalibroModulesHelper, :type => :helper do
   describe 'sort_by_granularity_and_name' do
     let(:package) { FactoryGirl.build(:module_result, kalibro_module: FactoryGirl.build(:kalibro_module_package)) }
-    let(:class_a) { FactoryGirl.build(:module_result, kalibro_module: FactoryGirl.build(:kalibro_module_class, name: 'a')) }
     let(:class_b) { FactoryGirl.build(:module_result, kalibro_module: FactoryGirl.build(:kalibro_module_class, name: 'b')) }
+    let(:class_a) { FactoryGirl.build(:module_result, kalibro_module: FactoryGirl.build(:kalibro_module_class, name: 'a')) }
+    let(:function) { FactoryGirl.build(:module_result, kalibro_module: FactoryGirl.build(:kalibro_module_function, name: 'c')) }
+    let(:method) { FactoryGirl.build(:module_result, kalibro_module: FactoryGirl.build(:kalibro_module_method, name: 'm')) }
 
     it 'is expected to order the ModuleResults by the Granularity first and then the KalibroModule name' do
-      unordered_modules = [class_b, package, class_a]
-      expect(helper.sort_by_granularity_and_name(unordered_modules)).to eq([package, class_a, class_b])
+      unordered_modules = [class_b, method, package, class_a, function]
+      expect(helper.sort_by_granularity_and_name(unordered_modules)).to eq([package, class_a, class_b, method, function])
+    end
+  end
+
+  describe 'ComparableGranularity' do
+    describe 'methods' do
+      describe '<=>' do
+        subject { KalibroModulesHelper::ComparableGranularity.new(:FUNCTION) }
+        let(:klass) { KalibroModulesHelper::ComparableGranularity.new(:CLASS) }
+        let(:method) { KalibroModulesHelper::ComparableGranularity.new(:METHOD) }
+
+        it 'is expected to place FUNCTION below all granularities' do
+          expect(subject <=> klass).to eq(-1)
+          expect(subject <=> method).to eq(-1)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
The comparison is theoretically invalid. Still we want to do it in order to show it for the users.
Therefore, we define an order by overriding Granularity.

Signed off by: Rafael Reggiani Manzo <rr.manzo@gmail.com>