### PR TITLE
Replace url route helpers by path ones

### DIFF
--- a/app/controllers/concerns/ownership_authentication.rb
+++ b/app/controllers/concerns/ownership_authentication.rb
@@ -76,7 +76,7 @@ module OwnershipAuthentication
   def check_reading_group_ownership(id)
     if current_user.reading_group_attributes.find_by_reading_group_id(id).nil?
       respond_to do |format|
-        format.html { redirect_to reading_group_url(id: id), notice: t('not_allowed') }
+        format.html { redirect_to reading_group_path(id: id), notice: t('not_allowed') }
         format.json { head :no_content }
       end
     end
@@ -87,7 +87,7 @@ module OwnershipAuthentication
   def check_kalibro_configuration_ownership(id)
     if current_user.kalibro_configuration_attributes.find_by_kalibro_configuration_id(id).nil?
       respond_to do |format|
-        format.html { redirect_to kalibro_configurations_url(id: id), notice: t('not_allowed') }
+        format.html { redirect_to kalibro_configurations_path(id: id), notice: t('not_allowed') }
         format.json { head :no_content }
       end
     end

--- a/app/views/compound_metric_configurations/edit.html.erb
+++ b/app/views/compound_metric_configurations/edit.html.erb
@@ -6,7 +6,7 @@
 
 <br>
 
-<%= form_for(@compound_metric_configuration, :url => kalibro_configuration_compound_metric_configuration_update_url(@compound_metric_configuration.kalibro_configuration_id, @compound_metric_configuration.id), method: :put) do |f| %>
+<%= form_for(@compound_metric_configuration, :url => kalibro_configuration_compound_metric_configuration_update_path(@compound_metric_configuration.kalibro_configuration_id, @compound_metric_configuration.id), method: :put) do |f| %>
   <%= render partial: 'form', locals: {f: f} %>
 <% end %>
 

--- a/app/views/kalibro_ranges/edit.html.erb
+++ b/app/views/kalibro_ranges/edit.html.erb
@@ -1,6 +1,6 @@
 <h1><%= t_action(:edit, KalibroRange) %></h1>
 
-<%= form_for(@kalibro_range, :url => kalibro_configuration_metric_configuration_kalibro_range_update_url(
+<%= form_for(@kalibro_range, :url => kalibro_configuration_metric_configuration_kalibro_range_update_path(
              @kalibro_configuration_id, @metric_configuration_id, @kalibro_range.id), method: :put) do |f|  %>
   <%= render partial: 'form', locals: {f: f} %>
 <% end %>

--- a/app/views/metric_configurations/edit.html.erb
+++ b/app/views/metric_configurations/edit.html.erb
@@ -2,7 +2,7 @@
   <h1><%= t('editing_metric_configuration') %></h1>
 </div>
 
-<%= form_for(@metric_configuration, :url => kalibro_configuration_metric_configuration_update_url(@kalibro_configuration_id, @metric_configuration.id), method: :put) do |f| %>
+<%= form_for(@metric_configuration, :url => kalibro_configuration_metric_configuration_update_path(@kalibro_configuration_id, @metric_configuration.id), method: :put) do |f| %>
   <%= render partial: 'form', locals: {f: f} %>
   <div class="row margin-left-none" style="margin-top: 20px">
   	<%= f.submit t('save'), class: 'btn btn-primary' %>

--- a/app/views/repositories/edit.html.erb
+++ b/app/views/repositories/edit.html.erb
@@ -2,6 +2,6 @@
   <h1><%= t_action(:edit, Repository) %></h1>
 </div>
 
-<%= form_for(@repository, :url => repository_update_url(@repository.id), method: :put) do |f| %>
+<%= form_for(@repository, :url => repository_update_path(@repository.id), method: :put) do |f| %>
   <%= render partial: 'form', locals: {f: f} %>
 <% end %>

--- a/app/views/repositories/new.html.erb
+++ b/app/views/repositories/new.html.erb
@@ -3,11 +3,11 @@
 </div>
 
 <% unless @project_id.nil? %>
-  <%= form_for(@repository, :url => project_repositories_url(@project_id)) do |f| %>
+  <%= form_for(@repository, :url => project_repositories_path(@project_id)) do |f| %>
     <%= render partial: 'form', locals: {f: f} %>
   <% end %>
 <% else %>
-  <%= form_for(@repository, :url => repositories_url) do |f| %>
+  <%= form_for(@repository, :url => repositories_path) do |f| %>
     <%= render partial: 'form', locals: {f: f} %>
   <% end %>
 <% end %>


### PR DESCRIPTION
Using URL helpers is not friendly with proxies like Colab. The path
helpers have the same effect unless we want sometime to render pages
outside Prezento context like embeds or sending emails.

Signed off by: Diego Araújo <diegoamc90@gmail.com>