### PR TITLE
Replace url helpers by the path ones

### DIFF
--- a/app/controllers/concerns/ownership_authentication.rb
+++ b/app/controllers/concerns/ownership_authentication.rb
@@ -53,7 +53,7 @@ module OwnershipAuthentication
   def check_repository_ownership(id)
     if current_user.repository_attributes.find_by_repository_id(id).nil?
       respond_to do |format|
-        format.html { redirect_to projects_url, notice: t('not_allowed') }
+        format.html { redirect_to projects_path, notice: t('not_allowed') }
         format.json { head :no_content }
       end
     end
@@ -65,7 +65,7 @@ module OwnershipAuthentication
   def check_project_ownership(id)
     if current_user.project_attributes.find_by_project_id(id).nil?
       respond_to do |format|
-        format.html { redirect_to projects_url, notice: t('not_allowed') }
+        format.html { redirect_to projects_path, notice: t('not_allowed') }
         format.json { head :no_content }
       end
     end

--- a/app/controllers/kalibro_configurations_controller.rb
+++ b/app/controllers/kalibro_configurations_controller.rb
@@ -54,7 +54,7 @@ class KalibroConfigurationsController < ApplicationController
     @kalibro_configuration.destroy
 
     respond_to do |format|
-      format.html { redirect_to kalibro_configurations_url }
+      format.html { redirect_to kalibro_configurations_path }
       format.json { head :no_content }
     end
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -56,7 +56,7 @@ class ProjectsController < ApplicationController
     set_project
     @project.destroy
     respond_to do |format|
-      format.html { redirect_to projects_url }
+      format.html { redirect_to projects_path }
       format.json { head :no_content }
     end
   end

--- a/app/controllers/reading_groups_controller.rb
+++ b/app/controllers/reading_groups_controller.rb
@@ -46,7 +46,7 @@ class ReadingGroupsController < ApplicationController
   def destroy
     @reading_group.destroy
     respond_to do |format|
-      format.html { redirect_to reading_groups_url }
+      format.html { redirect_to reading_groups_path }
       format.json { head :no_content }
     end
   end

--- a/spec/controllers/compound_metric_configurations_controller_spec.rb
+++ b/spec/controllers/compound_metric_configurations_controller_spec.rb
@@ -28,8 +28,7 @@ describe CompoundMetricConfigurationsController, :type => :controller do
         get :new, kalibro_configuration_id: kalibro_configuration.id
       end
 
-      it { is_expected.to redirect_to(kalibro_configurations_url(id: kalibro_configuration.id)) }
-      it { is_expected.to respond_with(:redirect) }
+      it { is_expected.to redirect_to kalibro_configurations_path id: kalibro_configuration.id }
     end
   end
 

--- a/spec/controllers/kalibro_configurations_controller_spec.rb
+++ b/spec/controllers/kalibro_configurations_controller_spec.rb
@@ -106,11 +106,7 @@ describe KalibroConfigurationsController, :type => :controller do
           delete :destroy, :id => kalibro_configuration.id
         end
 
-        it 'should redirect to the kalibro_configurations page' do
-          expect(response).to redirect_to kalibro_configurations_url
-        end
-
-        it { is_expected.to respond_with(:redirect) }
+        it { is_expected.to redirect_to kalibro_configurations_path }
       end
 
       context "when the user doesn't own the kalibro_configuration" do

--- a/spec/controllers/kalibro_ranges_controller_spec.rb
+++ b/spec/controllers/kalibro_ranges_controller_spec.rb
@@ -172,8 +172,7 @@ describe KalibroRangesController, :type => :controller do
           get :edit, id: kalibro_range.id, kalibro_configuration_id: metric_configuration.kalibro_configuration_id, metric_configuration_id: metric_configuration.id
         end
 
-        it { is_expected.to redirect_to(kalibro_configurations_url(id: metric_configuration.kalibro_configuration_id)) }
-        it { is_expected.to respond_with(:redirect) }
+        it { is_expected.to redirect_to kalibro_configurations_path id: metric_configuration.kalibro_configuration_id }
         it { is_expected.to set_flash[:notice].to("You're not allowed to do this operation") }
       end
     end

--- a/spec/controllers/metric_configurations_controller_spec.rb
+++ b/spec/controllers/metric_configurations_controller_spec.rb
@@ -53,8 +53,7 @@ describe MetricConfigurationsController, :type => :controller do
         post :new, kalibro_configuration_id: kalibro_configuration.id, metric_name: "Lines of Code", metric_collector_name: metric_collector.name
       end
 
-      it { is_expected.to redirect_to(kalibro_configurations_url(id: kalibro_configuration.id)) }
-      it { is_expected.to respond_with(:redirect) }
+      it { is_expected.to redirect_to kalibro_configurations_path id: kalibro_configuration.id }
     end
   end
 

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -119,11 +119,7 @@ describe ProjectsController, :type => :controller do
           delete :destroy, :id => @subject.id
         end
 
-        it 'should redirect to the projects page' do
-          expect(response).to redirect_to projects_url
-        end
-
-        it { is_expected.to respond_with(:redirect) }
+        it { is_expected.to redirect_to projects_path }
       end
 
       context "when the user doesn't own the project" do

--- a/spec/controllers/reading_groups_controller_spec.rb
+++ b/spec/controllers/reading_groups_controller_spec.rb
@@ -94,11 +94,7 @@ describe ReadingGroupsController, :type => :controller do
           delete :destroy, :id => @subject.id
         end
 
-        it 'should redirect to the reading groups page' do
-          expect(response).to redirect_to reading_groups_url
-        end
-
-        it { is_expected.to respond_with(:redirect) }
+        it { is_expected.to redirect_to reading_groups_path }
       end
 
       context "when the user doesn't own the reading group" do
@@ -118,7 +114,7 @@ describe ReadingGroupsController, :type => :controller do
         delete :destroy, :id => @subject.id
       end
 
-      it { is_expected.to redirect_to new_user_session_url }
+      it { is_expected.to redirect_to new_user_session_path }
     end
   end
 

--- a/spec/controllers/readings_controller_spec.rb
+++ b/spec/controllers/readings_controller_spec.rb
@@ -23,8 +23,7 @@ describe ReadingsController, :type => :controller do
         get :new, reading_group_id: reading_group.id
       end
 
-      it { is_expected.to redirect_to(reading_group_url(reading_group.id)) }
-      it { is_expected.to respond_with(:redirect) }
+      it { is_expected.to redirect_to reading_group_path reading_group.id }
     end
   end
 
@@ -86,8 +85,7 @@ describe ReadingsController, :type => :controller do
           get :edit, id: reading.id, reading_group_id: reading_group.id.to_s
         end
 
-        it { is_expected.to redirect_to(reading_group_url(reading_group.id)) }
-        it { is_expected.to respond_with(:redirect) }
+        it { is_expected.to redirect_to reading_group_path reading_group.id }
         it { is_expected.to set_flash[:notice].to("You're not allowed to do this operation") }
       end
     end

--- a/spec/controllers/repositories_controller_spec.rb
+++ b/spec/controllers/repositories_controller_spec.rb
@@ -41,8 +41,7 @@ describe RepositoriesController, :type => :controller do
             get :new, project_id: project.id.to_s
           end
 
-          it { is_expected.to redirect_to(projects_url) }
-          it { is_expected.to respond_with(:redirect) }
+          it { is_expected.to redirect_to(projects_path) }
         end
       end
 
@@ -120,8 +119,7 @@ describe RepositoriesController, :type => :controller do
           post :create, project_id: project.id, repository: repository_params
         end
 
-        it { is_expected.to redirect_to(projects_url) }
-        it { is_expected.to respond_with(:redirect) }
+        it { is_expected.to redirect_to projects_path }
       end
     end
 
@@ -208,8 +206,7 @@ describe RepositoriesController, :type => :controller do
           delete :destroy, id: repository.id
         end
 
-        it { is_expected.to redirect_to(projects_url) }
-        it { is_expected.to respond_with(:redirect) }
+        it { is_expected.to redirect_to projects_path }
       end
     end
 
@@ -249,8 +246,7 @@ describe RepositoriesController, :type => :controller do
           get :edit, id: repository.id
         end
 
-        it { is_expected.to redirect_to(projects_url) }
-        it { is_expected.to respond_with(:redirect) }
+        it { is_expected.to redirect_to projects_path }
         it { is_expected.to set_flash[:notice].to("You're not allowed to do this operation") }
       end
     end


### PR DESCRIPTION
This is expected to improve compatibility with reverse-proxies.

Still, for full compatibility, regarding redirections, we still may
need to set the default url options with the proxy host.

Signed-off-by: Rafael Reggiani Manzo <rr.manzo@gmail.com>