### PR TITLE
Aggregation form fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_script:
   - pushd kalibro_install
     # Remove bugged libzmq3 package, see https://github.com/travis-ci/travis-ci/issues/982 and https://github.com/travis-ci/travis-ci/issues/1715 for details
   - sudo apt-get remove libzmq3
-  - export KALIBRO_PROCESSOR_VERSION=v1.1.7.rc1
+  - export KALIBRO_PROCESSOR_VERSION=v1.1.7
   - export KALIBRO_CONFIGURATIONS_VERSION=v2.0.0
   - bash install.sh
   - popd

--- a/app/helpers/metric_configurations_helper.rb
+++ b/app/helpers/metric_configurations_helper.rb
@@ -1,6 +1,6 @@
 module MetricConfigurationsHelper
   def aggregation_options
-    [[t("aggregation_forms.AVERAGE"),"AVERAGE"], [t("aggregation_forms.MEDIAN"), "MEDIAN"], [t("aggregation_forms.MAXIMUM"), "MAXIMUM"], [t("aggregation_forms.MINIMUM"), "MINIMUM"], [t("aggregation_forms.STANDARD_DEVIATION"), "STANDARD_DEVIATION"], [t("aggregation_forms.COUNT"), "COUNT"]]
+    [[t("aggregation_forms.MEAN"),"MEAN"], [t("aggregation_forms.MEDIAN"), "MEDIAN"], [t("aggregation_forms.MAXIMUM"), "MAXIMUM"], [t("aggregation_forms.MINIMUM"), "MINIMUM"], [t("aggregation_forms.STANDARD_DEVIATION"), "STANDARD_DEVIATION"], [t("aggregation_forms.COUNT"), "COUNT"]]
   end
 
   def reading_group_options

--- a/config/locales/views/metric_configurations/en.yml
+++ b/config/locales/views/metric_configurations/en.yml
@@ -45,10 +45,9 @@ en:
     PACKAGE: "Package"
     SOFTWARE: "Software"
   aggregation_forms:
-    AVERAGE: "Average"
+    MEAN: "Mean"
     MEDIAN: "Median"
     MAXIMUM: "Maximum"
     MINIMUM: "Minimum"
     COUNT: "Count"
     STANDARD_DEVIATION: "Standard Deviation"
-

--- a/config/locales/views/metric_configurations/pt.yml
+++ b/config/locales/views/metric_configurations/pt.yml
@@ -49,7 +49,7 @@ pt:
     PACKAGE: "Pacote"
     SOFTWARE: "Software"
   aggregation_forms:
-    AVERAGE: "Média"
+    MEAN: "Média"
     MEDIAN: "Mediana"
     MAXIMUM: "Máxima"
     MINIMUM: "Mínima"

--- a/features/golden_path/configure_and_process.feature
+++ b/features/golden_path/configure_and_process.feature
@@ -1,0 +1,31 @@
+Feature: Create a new native configuration and process a repository using it
+  In order to view the results of a ruby repository
+  As a regular user
+  I should be able to configure a set of metrics and process a repository using them
+
+  @kalibro_configuration_restart @kalibro_processor_restart @javascript
+  Scenario: Create a ruby configuration and process a ruby repository
+    Given I am a regular user
+    And I am signed in
+    And I own a sample configuration
+    And I have a reading group named "Scholar"
+    And I have a sample repository
+    And I am at the Sample Configuration page
+    And I click the Add Metric link
+    And I click the "MetricFu" h3
+    And I click the Pain link
+    And I fill the Weight field with "2"
+    And I set the select field "Aggregation Form" as "Mean"
+    And I set the select field "Reading Group" as "Scholar"
+    When I press the Save button
+    Then I should see "Pain"
+    And I should see "2"
+    When I start to process that repository
+    And I wait up for a ready processing
+    And I ask for the last ready processing of the given repository
+    And I ask for the module result of the given processing
+    And I ask for the metric results of the given module result
+    When I visit the repository show page
+    And I click the "Tree Metric Results" h3
+    Then I should see the sample metric's name
+    And I should see the ruby metric results

--- a/features/repository/show/metric_results.feature
+++ b/features/repository/show/metric_results.feature
@@ -51,22 +51,6 @@ Feature: Repository metric results
     And I click the "Tree Metric Results" h3
     Then I should see "Repository process returned with error. There are no tree metric results."
 
-  @kalibro_processor_restart @kalibro_configuration_restart @javascript
-  Scenario: Should show the metric results after processing with a ruby metric configuration
-    Given I am a regular user
-    And I am signed in
-    And I have a sample configuration with ruby native metrics
-    And I have a sample repository
-    And I start to process that repository
-    And I wait up for a ready processing
-    And I ask for the last ready processing of the given repository
-    And I ask for the module result of the given processing
-    And I ask for the metric results of the given module result
-    When I visit the repository show page
-    And I click the "Tree Metric Results" h3
-    Then I should see the sample metric's name
-    And I should see the ruby metric results
-
   # TODO: Scenario: Should show the graphic of a given metric
   #         It was getting really difficult to test this because of Poltergeist's timeouts
   #       so we gave up on this for now

--- a/features/step_definitions/repository_steps.rb
+++ b/features/step_definitions/repository_steps.rb
@@ -59,6 +59,7 @@ end
 
 Given(/^I wait up for a ready processing$/) do
   while !@repository.has_ready_processing
+    expect(@repository.last_processing_state).to_not eq "ERROR"
     sleep(10)
   end
 end

--- a/features/tree_metric_configuration/create.feature
+++ b/features/tree_metric_configuration/create.feature
@@ -20,27 +20,10 @@ Feature: Tree Metric Configuration Creation
     And I click the "Analizo" h3
     And I click the Total Lines of Code link
     And I fill the Weight field with "2"
-    And I set the select field "Aggregation Form" as "Average"
+    And I set the select field "Aggregation Form" as "Mean"
     And I set the select field "Reading Group" as "Scholar"
     When I press the Save button
     Then I should see "Total Lines of Code"
-    Then I should see "2"
-
-  @kalibro_configuration_restart @javascript
-  Scenario: ruby metric configuration creation
-    Given I am a regular user
-    And I am signed in
-    And I own a sample configuration
-    And I have a reading group named "Scholar"
-    And I am at the Sample Configuration page
-    And I click the Add Metric link
-    And I click the "MetricFu" h3
-    And I click the Pain link
-    And I fill the Weight field with "2"
-    And I set the select field "Aggregation Form" as "Average"
-    And I set the select field "Reading Group" as "Scholar"
-    When I press the Save button
-    Then I should see "Pain"
     Then I should see "2"
 
   @kalibro_configuration_restart @javascript
@@ -68,7 +51,7 @@ Feature: Tree Metric Configuration Creation
     And I click the "Analizo" h3
     And I click the Total Abstract Classes link
     And I fill the Weight field with "2"
-    And I set the select field "Aggregation Form" as "Average"
+    And I set the select field "Aggregation Form" as "Mean"
     And I set the select field "Reading Group" as "Scholar"
     When I press the Save button
     Then I should see "Code must be unique within a kalibro configuration"

--- a/spec/helpers/metric_configurations_helper_spec.rb
+++ b/spec/helpers/metric_configurations_helper_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe MetricConfigurationsHelper, :type => :helper do
   describe 'aggregation_form_options' do
     it 'should return an array with the supported aggregation forms' do
-      expect(helper.aggregation_options).to eq [["Average","AVERAGE"], ["Median", "MEDIAN"], ["Maximum", "MAXIMUM"], ["Minimum", "MINIMUM"],
+      expect(helper.aggregation_options).to eq [["Mean","MEAN"], ["Median", "MEDIAN"], ["Maximum", "MAXIMUM"], ["Minimum", "MINIMUM"],
       ["Standard Deviation", "STANDARD_DEVIATION"], ["Count", "COUNT"]]
     end
   end


### PR DESCRIPTION
There were outdated tests that did not update from the deprecated
'Average' aggregation form to 'Mean'. Fix that, while simultaneously
refactoring the configuration creation and repository processing
features, into a single 'golden path' that tests boths, ensuring a very
common user task works as expected.

Signed-off-by: Daniel Miranda <danielkza2@gmail.com>