### PR TITLE
Fix CSRF protection error in Gitlab webhooks

### DIFF
--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -7,6 +7,9 @@ class RepositoriesController < ApplicationController
   before_action :set_repository, only: [:show, :edit, :update, :destroy, :state, :state_with_date, :process_repository]
   before_action :set_project_id_repository_types_and_configurations, only: [:new, :edit]
 
+  # Gitlab can't send a CSRF token, don't require one
+  skip_before_action :verify_authenticity_token, :only => [:notify_push]
+
   def index
     @repositories = Repository.all
   end

--- a/features/repository/notify_push.feature
+++ b/features/repository/notify_push.feature
@@ -3,7 +3,7 @@ Feature: Notify push to repository
   As a regular user
   I want to use a webhook in my repository to notify Mezuro of new pushes
 
-  @kalibro_configuration_restart @kalibro_processor_restart
+  @kalibro_configuration_restart @kalibro_processor_restart @enable_forgery_protection
   Scenario: Valid repository
     Given I am a regular user
     And I have a sample configuration with hotspot metrics
@@ -13,13 +13,13 @@ Feature: Notify push to repository
     When I push some commits to the repository
     Then Mezuro should process the repository again
 
-  @kalibro_configuration_restart @kalibro_processor_restart
+  @kalibro_configuration_restart @kalibro_processor_restart @enable_forgery_protection
   Scenario: Invalid repository
     Given I am a regular user
     When I push some commits to an invalid repository
     Then I should get a not found error
 
-  @kalibro_configuration_restart @kalibro_processor_restart
+  @kalibro_configuration_restart @kalibro_processor_restart @enable_forgery_protection
   Scenario: Repository with an errored processing
     Given I am a regular user
     And I have a sample reading group

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -20,3 +20,13 @@ AfterConfiguration do |config|
   KalibroClient::KalibroCucumberHelpers.clean_configurations
   KalibroClient::KalibroCucumberHelpers.clean_processor
 end
+
+Around('@enable_forgery_protection') do |scenario, block|
+  old_value = ActionController::Base.allow_forgery_protection
+  begin
+    ActionController::Base.allow_forgery_protection = true
+    block.call
+  ensure
+    ActionController::Base.allow_forgery_protection = old_value
+  end
+end


### PR DESCRIPTION
Gitlab Webhooks didn't work since their service does not have a CSRF protection token to send on the request. Disable that protection for the `notify_push` action of the Repositories Controller.