### PR TITLE
Refactor Webhook support to allow verification of parameters

### DIFF
--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -1,10 +1,13 @@
+require 'webhooks'
+
 include OwnershipAuthentication
 
 class RepositoriesController < ApplicationController
   before_action :authenticate_user!, except: [:show, :state, :state_with_date, :index, :notify_push]
   before_action :project_owner?, only: [:new, :create], unless: Proc.new { params[:project_id].nil? }
   before_action :repository_owner?, only: [:edit, :update, :destroy, :process_repository]
-  before_action :set_repository, only: [:show, :edit, :update, :destroy, :state, :state_with_date, :process_repository]
+  before_action :set_repository, only: [:show, :edit, :update, :destroy, :state, :state_with_date, :process_repository,
+                                        :notify_push]
   before_action :set_project_id_repository_types_and_configurations, only: [:new, :edit]
 
   # Gitlab can't send a CSRF token, don't require one
@@ -100,14 +103,21 @@ class RepositoriesController < ApplicationController
   end
 
   def notify_push
-    gitlab_event = request.headers['X-Gitlab-Event']
-    if gitlab_event.nil? || !gitlab_event.end_with?('Push Hook')
-      return render nothing: true, status: :unprocessable_entity
+    hook_info = Webhooks::GitLab.new(request, @repository)
+    if hook_info.valid_request?
+      if hook_info.valid_address?
+        if hook_info.valid_branch?
+          @repository.cancel_processing_of_repository unless %w(READY ERROR).include? @repository.last_processing_state
+          @repository.process
+        end
+
+        render nothing: true, status: :ok
+      else
+        render nothing: true, status: :forbidden
+      end
+    else
+      render nothing: true, status: :unprocessable_entity
     end
-    set_repository
-    @repository.cancel_processing_of_repository unless %w(READY ERROR).include? @repository.last_processing_state
-    @repository.process
-    render nothing: true, status: :ok
   end
 
   private

--- a/features/repository/notify_push.feature
+++ b/features/repository/notify_push.feature
@@ -7,7 +7,7 @@ Feature: Notify push to repository
   Scenario: Valid repository
     Given I am a regular user
     And I have a sample configuration with hotspot metrics
-    And I have a sample repository
+    And I have a Kalibro Client GitLab repository
     And I start to process that repository
     And I wait up for a ready processing
     When I push some commits to the repository
@@ -25,7 +25,7 @@ Feature: Notify push to repository
     And I have a sample reading group
     And I have a sample configuration with the Saikuro native metric
     And I have a compound metric configuration with script "rtrnaqdfwqefwqr213r2145211234ed a = b=2" within the given mezuro configuration
-    And I have a sample repository
+    And I have a Kalibro Client GitLab repository
     And I start to process that repository
     And I wait up for an error processing
     When I push some commits to the repository

--- a/features/step_definitions/repository_steps.rb
+++ b/features/step_definitions/repository_steps.rb
@@ -116,6 +116,10 @@ Given(/^I have a sample repository$/) do
   @independent_repository = FactoryGirl.create(:ruby_repository, kalibro_configuration_id: @kalibro_configuration.id)
 end
 
+Given(/^I have a Kalibro Client GitLab repository$/) do
+  @independent_repository = FactoryGirl.create(:kalibro_client_gitlab_repository, kalibro_configuration_id: @kalibro_configuration.id)
+end
+
 Given(/^I am at the All Repositories page$/) do
   visit repositories_path
 end
@@ -163,11 +167,19 @@ When(/^I get the Creation Date information as "(.*?)"$/) do |variable|
 end
 
 When(/^I push some commits to the repository$/) do
-  post repository_notify_push_path(id: @repository.id), {}, {'HTTP_X_GITLAB_EVENT' => 'Push Hook'}
+  request = FactoryGirl.build(:gitlab_webhook_request)
+  request.headers.each do |k, v|
+    header k, v
+  end
+  @response = post repository_notify_push_path(id: @repository.id), request.params
 end
 
 When(/^I push some commits to an invalid repository$/) do
-  @response = post repository_notify_push_path(id: 0), {}, {'HTTP_X_GITLAB_EVENT' => 'Push Hook'}
+  request = FactoryGirl.build(:gitlab_webhook_request)
+  request.headers.each do |k, v|
+    header k, v
+  end
+  @response = post repository_notify_push_path(id: 0), request.params
 end
 
 Then(/^I should see the sample metric's name$/) do

--- a/features/step_definitions/repository_steps.rb
+++ b/features/step_definitions/repository_steps.rb
@@ -168,18 +168,14 @@ end
 
 When(/^I push some commits to the repository$/) do
   request = FactoryGirl.build(:gitlab_webhook_request)
-  request.headers.each do |k, v|
-    header k, v
-  end
-  @response = post repository_notify_push_path(id: @repository.id), request.params
+  set_headers(request.headers)
+  page.driver.post(repository_notify_push_path(id: @repository.id), request.params)
 end
 
 When(/^I push some commits to an invalid repository$/) do
   request = FactoryGirl.build(:gitlab_webhook_request)
-  request.headers.each do |k, v|
-    header k, v
-  end
-  @response = post repository_notify_push_path(id: 0), request.params
+  set_headers(request.headers)
+  page.driver.post(repository_notify_push_path(id: 0), request.params)
 end
 
 Then(/^I should see the sample metric's name$/) do
@@ -283,5 +279,5 @@ Then(/^Mezuro should process the repository again$/) do
 end
 
 Then(/^I should get a not found error$/) do
-  expect(@response.status).to eq(404)
+  expect(page.driver.status_code).to eq(404)
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -20,8 +20,11 @@ end
 # instead of editing this one. Cucumber will automatically load all features/**/*.rb
 # files.
 
+require 'warden'
 require 'cucumber/rails'
 require 'capybara/poltergeist'
+require_relative 'header'
+
 #Capybara.default_driver = :poltergeist
 Capybara.javascript_driver = :poltergeist
 Capybara.default_max_wait_time = 20 # default is 2 seconds
@@ -81,5 +84,6 @@ Cucumber::Rails::Database.javascript_strategy = :truncation
 # KalibroClient hooks
 require 'kalibro_client/kalibro_cucumber_helpers/hooks.rb'
 
-# Warden test helpers so the user authentication can be as fast as possible
-include Warden::Test::Helpers
+Warden.test_mode!
+World(Warden::Test::Helpers, HeaderUtils)
+

--- a/features/support/header.rb
+++ b/features/support/header.rb
@@ -1,0 +1,15 @@
+module HeaderUtils
+  def set_header(key, value)
+    header_method = nil
+    if defined?(page) && ! page.driver.nil?
+      header_method = [:add_header, :header].find(&page.driver.method(:respond_to?))
+    end
+
+    raise StandardError.new("No header setting method available in current driver: #{page.driver}") unless header_method
+    page.driver.send(header_method, key, value)
+  end
+
+  def set_headers(headers)
+    headers.each(&method(:set_header))
+  end
+end

--- a/lib/webhooks.rb
+++ b/lib/webhooks.rb
@@ -1,0 +1,5 @@
+require 'webhooks/base'
+require 'webhooks/gitlab'
+
+module Webhooks
+end

--- a/lib/webhooks/base.rb
+++ b/lib/webhooks/base.rb
@@ -1,0 +1,44 @@
+module Webhooks
+  class Base
+    attr_reader :request, :repository
+
+    def initialize(request, repository)
+      @request = request
+      @repository = repository
+    end
+
+    # Returns true if and only if the remote addresses in the request and repository match.
+    def valid_address?
+      repository.address == webhook_address
+    end
+
+    # Returns true if and only if the branch in the request and repository match.
+    def valid_branch?
+      repository.branch == webhook_branch
+    end
+
+    # Returns true if the request parameters, as determined by the particular hook service, are valid
+    # It will usually check headers, IP ranges, signatures, or any other relevant information.
+    def valid_request?; raise NotImplementedError; end
+
+    # Extracts the remote address from the webhook request.
+    def webhook_address; raise NotImplementedError; end
+
+    # Extracts the branch from the webhook request.
+    def webhook_branch; raise NotImplementedError; end
+
+    protected
+
+    # Converts a git ref name to a branch. This is an utility function for webhook formats that only provide the ref
+    # updated in their information. Returns nil if the passed parameter is not a valid ref.
+    # The expected format is 'refs/heads/#{branch_name}'. Anything else will be rejected.
+    def branch_from_ref(ref)
+      return nil if !ref
+
+      ref = ref.split('/')
+      return nil if ref.size != 3 || ref[0..1] != ['refs', 'heads']
+
+      ref.last
+    end
+  end
+end

--- a/lib/webhooks/gitlab.rb
+++ b/lib/webhooks/gitlab.rb
@@ -1,0 +1,19 @@
+module Webhooks
+  class GitLab < Base
+    def valid_request?
+      request.headers['X-Gitlab-Event'] == 'Push Hook'
+    end
+
+    def webhook_address
+      begin
+        request.params.fetch(:project).fetch(:git_http_url)
+      rescue KeyError
+        return nil
+      end
+    end
+
+    def webhook_branch
+      branch_from_ref(request.params[:ref])
+    end
+  end
+end

--- a/spec/controllers/repositories_controller_spec.rb
+++ b/spec/controllers/repositories_controller_spec.rb
@@ -475,10 +475,7 @@ describe RepositoriesController, :type => :controller do
     let(:webhook_request) { FactoryGirl.build(:gitlab_webhook_request) }
 
     def post_push
-      webhook_request.headers.each do |k, v|
-        @request.headers[k] = v
-      end
-
+      @request.headers.merge!(webhook_request.headers)
       post :notify_push, {id: repository.id, format: :json}.merge(webhook_request.params)
     end
 

--- a/spec/controllers/repositories_controller_spec.rb
+++ b/spec/controllers/repositories_controller_spec.rb
@@ -471,11 +471,15 @@ describe RepositoriesController, :type => :controller do
   end
 
   describe 'notify_push' do
-    let(:repository) { FactoryGirl.build(:repository) }
+    let(:repository) { FactoryGirl.build(:kalibro_client_gitlab_repository) }
+    let(:webhook_request) { FactoryGirl.build(:gitlab_webhook_request) }
 
     def post_push
-      @request.env['HTTP_X_GITLAB_EVENT'] = ['Push Hook', 'Tag Push Hook'].sample
-      post :notify_push, id: repository.id, format: :json
+      webhook_request.headers.each do |k, v|
+        @request.headers[k] = v
+      end
+
+      post :notify_push, {id: repository.id, format: :json}.merge(webhook_request.params)
     end
 
     context 'with a valid repository' do
@@ -483,35 +487,67 @@ describe RepositoriesController, :type => :controller do
         Repository.expects(:find).with(repository.id).returns(repository)
       end
 
-      context 'when the repository is being processed' do
-        before do
-          repository.expects(:last_processing_state).returns('INTERPRETING')
-          repository.expects(:cancel_processing_of_repository).once
-          repository.expects(:process).once
+      context 'without a valid address' do
+        before :each do
+          Webhooks::Base.any_instance.expects(:valid_address?).returns(false)
           post_push
         end
 
-        it { is_expected.to respond_with(:ok) }
+        it { is_expected.to respond_with(:forbidden) }
       end
 
-      context "when the repository's processing resulted in an error" do
-        before do
-          repository.expects(:last_processing_state).returns('ERROR')
-          repository.expects(:process).once
-          post_push
+      context 'with a valid address' do
+        before :each do
+          Webhooks::Base.any_instance.expects(:valid_address?).returns(true)
         end
 
-        it { is_expected.to respond_with(:ok) }
-      end
+        context 'without a matching branch' do
+          before :each do
+            Webhooks::Base.any_instance.expects(:valid_branch?).returns(false)
+            repository.expects(:cancel_processing_of_repository).never
+            repository.expects(:process).never
+            post_push
+          end
 
-      context 'when the repository is not being processed' do
-        before do
-          repository.expects(:last_processing_state).returns('READY')
-          repository.expects(:process).once
-          post_push
+          it { is_expected.to respond_with(:ok) }
         end
 
-        it { is_expected.to respond_with(:ok) }
+        context 'with a matching branch' do
+          before :each do
+            Webhooks::Base.any_instance.expects(:valid_branch?).returns(true)
+          end
+
+          context 'when the repository is being processed' do
+            before do
+              repository.expects(:last_processing_state).returns('INTERPRETING')
+              repository.expects(:cancel_processing_of_repository).once
+              repository.expects(:process).once
+              post_push
+            end
+
+            it { is_expected.to respond_with(:ok) }
+          end
+
+          context "when the repository's processing resulted in an error" do
+            before do
+              repository.expects(:last_processing_state).returns('ERROR')
+              repository.expects(:process).once
+              post_push
+            end
+
+            it { is_expected.to respond_with(:ok) }
+          end
+
+          context 'when the repository is not being processed' do
+            before do
+              repository.expects(:last_processing_state).returns('READY')
+              repository.expects(:process).once
+              post_push
+            end
+
+            it { is_expected.to respond_with(:ok) }
+          end
+        end
       end
     end
 
@@ -522,14 +558,6 @@ describe RepositoriesController, :type => :controller do
       end
 
       it { is_expected.to respond_with(:not_found) }
-    end
-
-    context 'with an invalid header' do
-      before :each do
-        post :notify_push, id: repository.id, format: :json
-      end
-
-      it { is_expected.to respond_with(:unprocessable_entity) }
     end
   end
 end

--- a/spec/factories/repositories.rb
+++ b/spec/factories/repositories.rb
@@ -36,6 +36,18 @@ FactoryGirl.define do
     kalibro_configuration_id 1
   end
 
+  factory :kalibro_client_gitlab_repository, class: Repository do
+    id 3
+    name "KalibroClient"
+    description "KalibroClient"
+    license "GPLv3"
+    period 1
+    scm_type "GIT"
+    address "https://gitlab.com/mezuro/kalibro_client.git"
+    branch 'master'
+    kalibro_configuration_id 1
+  end
+
   factory :another_repository, parent: :repository do
     id 2
   end

--- a/spec/factories/webhooks.rb
+++ b/spec/factories/webhooks.rb
@@ -1,0 +1,40 @@
+require 'action_controller/test_case'
+
+class RequestInfo
+  attr_accessor :headers, :params
+
+  def request
+    req = ActionController::TestRequest.new
+    headers.each { |k, v| req.headers[k] = v }
+    params.each { |k, v| req.update_param(k, v) }
+    req
+  end
+end
+
+FactoryGirl.define do
+  factory :request, class: RequestInfo do
+    headers {}
+    params {}
+  end
+
+  factory :gitlab_webhook_request, parent: :request do
+    headers { { 'X-Gitlab-Event' => 'Push Hook' } }
+
+    # Excerpt From http://doc.gitlab.com/ee/web_hooks/web_hooks.html
+    params { {
+      "object_kind" =>  "push",
+      "ref" =>  "refs/heads/master",
+      "project" => {
+        "name" => "Kalibro Client",
+        "description" => "",
+        "git_ssh_url" => "git@example.com:mezuro/kalibro_client.git",
+        "git_http_url" => "https://gitlab.com/mezuro/kalibro_client.git",
+        "path_with_namespace" => "mezuro/kalibro_client",
+        "default_branch" => "master",
+        "url" => "git@example.com:mezuro/kalibro_client.git",
+        "ssh_url" => "git@example.com:mezuro/kalibro_client.git",
+        "http_url" => "https://gitlab.com/mezuro/kalibro_client.git"
+      }
+    } }
+  end
+end

--- a/spec/lib/webhooks/base_spec.rb
+++ b/spec/lib/webhooks/base_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+require 'webhooks'
+
+RSpec.describe Webhooks::Base do
+  let(:request) { ActionController::TestRequest.new }
+  let(:repository) { FactoryGirl.build(:repository) }
+
+  subject { described_class.new(request, repository) }
+
+  describe 'initialize' do
+    it 'is expected to initialize request and repository' do
+      expect(subject.request).to eq(request)
+      expect(subject.repository).to eq(repository)
+    end
+  end
+
+  describe 'valid_request?' do
+    it 'is expected to not be implemented' do
+      expect { subject.valid_request? }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe 'webhook_address' do
+    it 'is expected to not be implemented' do
+      expect { subject.webhook_address }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe 'webhook_branch' do
+    it 'is expected to not be implemented' do
+      expect { subject.webhook_branch }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe 'valid_address?' do
+    it 'is expected to return true if the repository and webhook addresses match' do
+      subject.expects(:webhook_address).returns(repository.address)
+      expect(subject.valid_address?).to eq(true)
+    end
+
+    it "is expected to return false if the repository and webhook addresses don't match" do
+      subject.expects(:webhook_address).returns('test')
+      expect(subject.valid_address?).to eq(false)
+    end
+  end
+
+  describe 'valid_branch?' do
+    it 'is expected to return true if the repository and webhook branches match' do
+      subject.expects(:webhook_branch).returns(repository.branch)
+      expect(subject.valid_branch?).to eq(true)
+    end
+
+    it "is expected to return false if the repository and webhook addresses don't match" do
+      subject.expects(:webhook_branch).returns('test')
+      expect(subject.valid_branch?).to eq(false)
+    end
+  end
+
+  describe 'branch_from_ref' do
+    cases = {
+        nil => nil,
+        'refs/heads/master' => 'master',
+        'refs/tags/test' => nil,
+        'test' => nil,
+        '' => nil
+    }
+
+    cases.each do |input, output|
+      it "is expected to return #{output.inspect} for #{input.inspect}" do
+        expect(subject.send(:branch_from_ref, input)).to eq(output)
+      end
+    end
+  end
+end

--- a/spec/lib/webhooks/gitlab_spec.rb
+++ b/spec/lib/webhooks/gitlab_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+require 'webhooks'
+
+RSpec.describe Webhooks::GitLab do
+  let(:request) { FactoryGirl.build(:gitlab_webhook_request).request }
+  let(:repository) { FactoryGirl.build(:repository) }
+  subject { described_class.new(request, repository) }
+
+  describe 'valid_request?' do
+    context 'with the correct Gitlab header value' do
+      it 'is expected to return true' do
+        expect(subject.valid_request?).to be(true)
+      end
+    end
+
+    context 'with an incorrect Gitlab header value' do
+      let(:request) { FactoryGirl.build(:gitlab_webhook_request, headers: { 'X-Gitlab-Event' => 'Merge Hook' }).request }
+      it 'is expected to return false' do
+        expect(subject.valid_request?).to be(false)
+      end
+    end
+
+    context 'without a GitLab header' do
+      let(:request) { FactoryGirl.build(:gitlab_webhook_request, headers: {}).request }
+      it 'is expected to return false' do
+        expect(subject.valid_request?).to be(false)
+      end
+    end
+  end
+
+  describe 'webhook_address' do
+    context 'the git URL is present' do
+      it 'is expected to return the  URL' do
+        expect(subject.webhook_address).to eq(request.params[:project][:git_http_url])
+      end
+    end
+
+    context'the git URL is not present' do
+      it 'is expected to return nil' do
+        request.expects(:params).returns({})
+        expect(subject.webhook_address).to be_nil
+      end
+    end
+  end
+
+  describe 'webhook_branch' do
+    context 'the git ref is present' do
+      it 'is expected to return the branch from the ref' do
+        expect(subject.webhook_branch).to eq('master')
+      end
+    end
+
+    context 'the git ref is not present' do
+      it 'is expected to return nil' do
+        request.expects(:params).returns({})
+        expect(subject.webhook_branch).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ensure webhook requests are only accepted after proper verification of
expected headers, repository address and branch.

To that effect, split up the logic to extract that information from
requests to it's own class, and use it in the notify_push action.

Also, add factories to make better testing of the notify_push action
possible, such as a factory similar to a real request from Gitlab, and
one for the Kalibro Client repository on Gitlab.

Adding other hook providers should be quite a lot easier after this is
applied.

This fixes #326.