### PR TITLE
Make Compound Metric Config. metric list not include Hotspot metrics

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -11,6 +11,7 @@ Prezento is the web interface for Mezuro.
 * Add latest configurations list to the homepage
 * Move tutorials to mezuro.github.io
 * Pluralize navigation menu links
+* Make Compound Metric Config. metric list not include Hotspot metrics
 * Fix 'Tree Metrics' and 'Hotspot Metrics' PT translations in Configuration show view  
 
 == v0.11.3 - 01/04/2016

--- a/app/controllers/compound_metric_configurations_controller.rb
+++ b/app/controllers/compound_metric_configurations_controller.rb
@@ -1,4 +1,6 @@
 class CompoundMetricConfigurationsController < BaseMetricConfigurationsController
+  ALLOWED_METRIC_TYPES = %w(NativeMetricSnapshot CompoundMetricSnapshot)
+
   before_action :set_metric_configurations, only: [:new, :edit]
 
   protected
@@ -11,8 +13,14 @@ class CompoundMetricConfigurationsController < BaseMetricConfigurationsControlle
     params.require(:metric_configuration).permit(:reading_group_id, :weight, :metric => [:name, :description, :script, :code, :scope => [:type]])
   end
 
+  def allowed_metric_configurations(kalibro_configuration_id)
+    MetricConfiguration.metric_configurations_of(kalibro_configuration_id).select { |metric_configuration|
+      ALLOWED_METRIC_TYPES.include?(metric_configuration.metric.type)
+    }
+  end
+
   def set_metric_configurations
-    @metric_configurations = MetricConfiguration.metric_configurations_of(@kalibro_configuration.id)
+    @metric_configurations = allowed_metric_configurations(@kalibro_configuration.id)
   end
 
   def metric_type

--- a/features/compound_metric_configuration/create.feature
+++ b/features/compound_metric_configuration/create.feature
@@ -49,3 +49,16 @@ Feature: Compound Metric Configuration Creation
     When I press the Save button
     Then I should see "Code must be unique within a kalibro configuration"
 
+  @kalibro_configuration_restart @javascript
+  Scenario: compound metric configuration creation must not include non-tree metrics
+    Given I am a regular user
+    And I am signed in
+    And I own a sample configuration
+    And I have a reading group named "Scholar"
+    And I have a tree metric configuration
+    And I have a hotspot metric configuration
+    And I have a sample compound metric configuration within the given mezuro configuration
+    And I am at the Sample Configuration page
+    And I click the Add Metric link
+    When I click the Compound Metric link
+    Then I should see only tree and compound metrics in the Created Metrics list

--- a/features/step_definitions/compound_metric_configuration_steps.rb
+++ b/features/step_definitions/compound_metric_configuration_steps.rb
@@ -40,3 +40,14 @@ Then(/^I should be at compound metric configuration sample page$/) do
   expect(page).to have_content(@compound_metric_configuration.metric.name)
   expect(page).to have_content("Ranges")
 end
+
+Then(/^I should see only tree and compound metrics in the Created Metrics list$/) do
+  metrics = MetricConfiguration.metric_configurations_of(@kalibro_configuration.id).map(&:metric)
+  metrics_by_code = Hash[metrics.map { |metric| [metric.code, metric] }]
+
+  get_table_column_values('#created-metrics-accordion', 'Code') do |code|
+    metric = metrics_by_code[code]
+    expect(metric).not_to be_nil
+    expect(%w(NativeMetricSnapshot CompoundMetricSnapshot)).to include(metric.type)
+  end
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -24,6 +24,7 @@ require 'warden'
 require 'cucumber/rails'
 require 'capybara/poltergeist'
 require_relative 'header'
+require_relative 'tables'
 
 #Capybara.default_driver = :poltergeist
 Capybara.javascript_driver = :poltergeist
@@ -85,5 +86,4 @@ Cucumber::Rails::Database.javascript_strategy = :truncation
 require 'kalibro_client/kalibro_cucumber_helpers/hooks.rb'
 
 Warden.test_mode!
-World(Warden::Test::Helpers, HeaderUtils)
-
+World(Warden::Test::Helpers, HeaderUtils, TableUtils)

--- a/features/support/tables.rb
+++ b/features/support/tables.rb
@@ -1,0 +1,15 @@
+module TableUtils
+  def get_table_column_values(selector, column)
+    column = column.strip
+
+    within(selector) do
+      table_columns = all('th').map { |table_column| table_column.text.strip }
+      column_index = table_columns.index(column)
+      expect(column_index).not_to be_nil
+
+      all("tr > td:nth-child(#{column_index + 1})").each do |element|
+        yield element.text.strip
+      end
+    end
+  end
+end


### PR DESCRIPTION
It makes it harder for an user to mistakenly add a metric to their
script that will never work.

Signed-off-by: Eduardo Araújo <duduktamg@hotmail.com>

Fixes #322.