### PR TITLE
Remove Show button for hotspot metric configurations

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -4,6 +4,8 @@ Prezento is the web interface for Mezuro.
 
 == Unreleased
 
+* Remove Show button for hotspot metric configurations
+
 == v0.11.3 - 01/04/2016
 
 Update KalibroClient error API which now uses Likeno errors

--- a/app/views/kalibro_configurations/_metric_configurations.html.erb
+++ b/app/views/kalibro_configurations/_metric_configurations.html.erb
@@ -1,22 +1,22 @@
 <tr>
   <td><%= metric_configuration.metric.name %></td>
   <td><%= metric_configuration.metric.code %></td>
-  <% unless metric_configuration.metric.is_a? KalibroClient::Entities::Miscellaneous::HotspotMetric %>
+  <% unless hotspot_metric_configuration?(metric_configuration) %>
     <td><%= metric_configuration.weight %></td>
-  <% end %>
-  <td>
-    <%= link_to_show_page(metric_configuration, @kalibro_configuration.id) %>
-  </td>
-  <% if kalibro_configuration_owner? @kalibro_configuration.id %>
-    <% unless hotspot_metric_configuration?(metric_configuration) %>
+    <td>
+      <%= link_to_show_page(metric_configuration, @kalibro_configuration.id) %>
+    </td>
+    <% if kalibro_configuration_owner? @kalibro_configuration.id %>
       <td>
         <%= link_to_edit_form(metric_configuration, @kalibro_configuration.id) %>
       </td>
     <% end %>
+  <% end %>
+  <% if kalibro_configuration_owner? @kalibro_configuration.id %>
     <td>
-    <%= link_to t_action(:destroy, MetricConfiguration), kalibro_configuration_metric_configuration_path(@kalibro_configuration.id, metric_configuration.id),
-        method: :delete, data: { confirm: t('want_destroy_metric_configuration') },
-        class: 'btn btn-danger' %>
+      <%= link_to t_action(:destroy, MetricConfiguration), kalibro_configuration_metric_configuration_path(@kalibro_configuration.id, metric_configuration.id),
+                  method: :delete, data: {confirm: t('want_destroy_metric_configuration')},
+                  class: 'btn btn-danger' %>
     </td>
   <% end %>
 </tr>


### PR DESCRIPTION
This removes the `Show` button for hotspot metric configurations on the
configurations page.

Signed-off-by: Daniel Miranda <danielkza2@gmail.com>

Fixes #310.