### PR TITLE
Fix translations of "Tree Metrics" and "Hotspot Metrics"

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -11,6 +11,7 @@ Prezento is the web interface for Mezuro.
 * Add latest configurations list to the homepage
 * Move tutorials to mezuro.github.io
 * Pluralize navigation menu links
+* Fix 'Tree Metrics' and 'Hotspot Metrics' PT translations in Configuration show view  
 
 == v0.11.3 - 01/04/2016
 

--- a/app/views/kalibro_configurations/show.html.erb
+++ b/app/views/kalibro_configurations/show.html.erb
@@ -12,7 +12,7 @@
   <%= link_to t_action(:add, MetricConfiguration), kalibro_configuration_choose_metric_path(@kalibro_configuration.id), class: 'btn btn-info' %>
 <% end %>
 <div id="tree_metrics">
-<h2><%= t('tree_metric').pluralize %></h2>
+<h2><%= t('tree_metrics') %></h2>
 
 <table class="table table-hover" id="tree_metric_configurations">
   <thead>
@@ -36,7 +36,7 @@
 <hr>
 
 <div id="hotspot_metrics">
-<h2><%= t('hotspot_metric').pluralize %></h2>
+<h2><%= t('hotspot_metrics') %></h2>
 
 <table class="table table-hover" id="hotspot_metric_configurations">
   <thead>


### PR DESCRIPTION
Fixes view to use the correct translation keys that already existed.

Fixes #333.

Signed-off-by: Daniel Miranda <danielkza2@gmail.com>