### PR TITLE
Fix home page latest content cache efectiveness

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -16,6 +16,7 @@ Prezento is the web interface for Mezuro.
 * Fix 'Tree Metrics' and 'Hotspot Metrics' PT translations in Configuration show view  
 * Show the notify push url for the repository's owner (Gitlab only)
 * Support for hiding repositories
+* Fix home latest content caching effectiveness
 
 == v0.11.3 - 01/04/2016
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,7 +1,15 @@
 class HomeController < ApplicationController
-  def index
-    @latest_projects = Project.latest(5)
-    @latest_repositories = Repository.latest(5)
-    @latest_configurations = KalibroConfiguration.latest(5)
+  helper_method :latest_projects, :latest_repositories, :latest_configurations
+
+  def latest_projects(count)
+    Project.latest(count)
+  end
+
+  def latest_repositories(count)
+    Repository.latest(count)
+  end
+
+  def latest_configurations(count)
+    KalibroConfiguration.latest(count)
   end
 end

--- a/app/models/kalibro_configuration.rb
+++ b/app/models/kalibro_configuration.rb
@@ -19,6 +19,13 @@ class KalibroConfiguration < KalibroClient::Entities::Configurations::KalibroCon
     self.public_or_owned_by_user
   end
 
+  def self.latest(count = 1)
+    all.sort { |one, another| another.id <=> one.id }.select { |kalibro_configuration|
+      attributes = kalibro_configuration.attributes
+      attributes && attributes.public
+    }.first(count)
+  end
+
   def attributes
     @attributes ||= KalibroConfigurationAttributes.find_by(kalibro_configuration_id: self.id)
   end
@@ -27,9 +34,5 @@ class KalibroConfiguration < KalibroClient::Entities::Configurations::KalibroCon
     attributes.destroy unless attributes.nil?
     @attributes = nil
     super
-  end
-
-  def self.latest(count=1)
-    all.sort { |one, another| another.id <=> one.id }.select { |kalibro_configuration| kalibro_configuration.attributes.public }.first(count)
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -17,7 +17,10 @@ class Project < KalibroClient::Entities::Processor::Project
   end
 
   def self.latest(count = 1)
-    all.sort { |a, b| b.id <=> a.id }.select { |project| project.attributes.public }.first(count)
+    all.sort { |one, another| another.id <=> one.id }.select { |project|
+      attributes = project.attributes
+      attributes && attributes.public
+    }.first(count)
   end
 
   def attributes

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -13,7 +13,7 @@
 
       <ul>
         <% cache action_suffix: 'latest_projects' do %>
-          <% @latest_projects.each do |project| %>
+          <% latest_projects(5).each do |project| %>
             <li><%= link_to(project.name, project_path(project.id)) %></li>
           <% end %>
         <% end %>
@@ -24,7 +24,7 @@
 
       <ul>
         <% cache action_suffix: 'latest_repositories' do %>
-          <% @latest_repositories.each do |repository| %>
+          <% latest_repositories(5).each do |repository| %>
             <li><%= link_to(repository.name, repository_path(repository.id)) %></li>
           <% end %>
         <% end %>
@@ -35,7 +35,7 @@
 
       <ul>
         <% cache action_suffix: 'latest_configurations' do %>
-          <% @latest_configurations.each do |configuration| %>
+          <% latest_configurations(5).each do |configuration| %>
             <li><%= link_to(configuration.name, kalibro_configuration_path(configuration.id)) %></li>
           <% end %>
         <% end %>

--- a/features/homepage.feature
+++ b/features/homepage.feature
@@ -7,7 +7,7 @@ Feature: Homepage
   Scenario: Before signing in
     Given I have a project named "GCC"
     And there is a public configuration created named "Test Configuration"
-    And I have a sample repository named "Test Repository"
+    And I have a public repository named "Test Repository"
     Then I am at the homepage
     And I should see "Home"
     And I should see "Projects"

--- a/features/homepage.feature
+++ b/features/homepage.feature
@@ -3,9 +3,11 @@ Feature: Homepage
   As a regular user
   I want to have in one page useful links to manage my account and session
 
-  @kalibro_processor_restart
+  @kalibro_configurations_restart @kalibro_processor_restart
   Scenario: Before signing in
     Given I have a project named "GCC"
+    And there is a public configuration created named "Test Configuration"
+    And I have a sample repository named "Test Repository"
     Then I am at the homepage
     And I should see "Home"
     And I should see "Projects"
@@ -19,6 +21,8 @@ Feature: Homepage
     And I should see "Latest repositories"
     And I should see "Latest configurations"
     Then I should see "GCC" only "1" times
+    Then I should see "Test Configuration" only "1" times
+    Then I should see "Test Repository" only "1" times
 
   Scenario: Signed in
     Given I am a regular user

--- a/features/step_definitions/kalibro_configuration_steps.rb
+++ b/features/step_definitions/kalibro_configuration_steps.rb
@@ -87,6 +87,12 @@ Given(/^there is a public configuration created$/) do
   FactoryGirl.create(:kalibro_configuration_attributes, kalibro_configuration_id: @public_kc.id)
 end
 
+Given(/^there is a public configuration created named "(.*?)"$/) do |name|
+  @kalibro_configuration = FactoryGirl.create(:public_kalibro_configuration, name: name)
+  FactoryGirl.create(:kalibro_configuration_attributes, kalibro_configuration_id: @kalibro_configuration.id)
+end
+
+
 Given(/^there is a private configuration created$/) do
   @private_kc = FactoryGirl.create(:another_kalibro_configuration)
   FactoryGirl.create(:kalibro_configuration_attributes, :private, kalibro_configuration_id: @private_kc.id, user: FactoryGirl.create(:another_user, id: nil, email: "private@email.com"))

--- a/features/step_definitions/repository_steps.rb
+++ b/features/step_definitions/repository_steps.rb
@@ -135,6 +135,15 @@ Given(/^I have a sample configuration with the (\w+) native metric$/) do |metric
                                              kalibro_configuration_id: @kalibro_configuration.id})
 end
 
+Given(/^I have a public repository named "(.*?)"$/) do |name|
+  @repository = FactoryGirl.create(:repository,
+                                   project_id: nil,
+                                   kalibro_configuration_id: @kalibro_configuration.id,
+                                   id: nil,
+                                   name: name)
+  FactoryGirl.create(:repository_attributes, {repository_id: @repository.id})
+end
+
 When(/^I click on the sample metric's name$/) do
   find_link(@metric_results.first.metric_configuration.metric.name).trigger('click')
 end

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -1,14 +1,8 @@
 require 'rails_helper'
 
 describe HomeController, :type => :controller do
-  context 'Method' do
-    context '#index' do
-      before :each do
-        Project.expects(:latest).with(5).returns([])
-        Repository.expects(:latest).with(5).returns([])
-        KalibroConfiguration.expects(:latest).with(5).returns([])
-      end
-
+  context 'actions' do
+    context 'index' do
       describe 'Rendering' do
         before :each do
           get :index
@@ -38,6 +32,35 @@ describe HomeController, :type => :controller do
         after do
           I18n.locale = I18n.default_locale
         end
+      end
+    end
+  end
+
+  context 'helpers' do
+    describe 'latest_repositories' do
+      let(:repositories) { mock }
+
+      it 'should fetch the latest content' do
+        Repository.expects(:latest).with(5).returns(repositories)
+        expect(subject.latest_repositories(5)).to be(repositories)
+      end
+    end
+
+    describe 'latest_projects' do
+      let(:projects) { mock }
+
+      it 'should fetch the latest content' do
+        Project.expects(:latest).with(5).returns(projects)
+        expect(subject.latest_projects(5)).to be(projects)
+      end
+    end
+
+    describe 'latest_configurations' do
+      let(:configurations) { mock }
+
+      it 'should fetch the latest content' do
+        KalibroConfiguration.expects(:latest).with(5).returns(configurations)
+        expect(subject.latest_configurations(5)).to be(configurations)
       end
     end
   end


### PR DESCRIPTION
There were instance variables filled by fetching the latest content
every time, defeating the purpose of the fragment caches in the view.

Replace them with helper methods, that also make the number of items
visible in the view.

Fixes #339.
Signed-off-by: otaviocv <otavio@deluqui.com.br>