### PR TITLE
Expose notify push url

### DIFF
--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -14,6 +14,7 @@ Prezento is the web interface for Mezuro.
 * Add missing translation for CompoundMetric
 * Make Compound Metric Config. metric list not include Hotspot metrics
 * Fix 'Tree Metrics' and 'Hotspot Metrics' PT translations in Configuration show view  
+* Show the notify push url for the repository's owner (Gitlab only)
 
 == v0.11.3 - 01/04/2016
 

--- a/app/views/repositories/show.html.erb
+++ b/app/views/repositories/show.html.erb
@@ -38,10 +38,12 @@
 </p>
 
 <% if repository_owner? @repository.id %>
-  <p>
-    <strong><%= t('repository.show.notify_push_url') %>:</strong>
-    <%= repository_notify_push_url(@repository.id) %>
-  </p>
+  <strong><%= t('repository.show.notify_push_url') %>:</strong>
+  <input id="notify_url" value="<%= repository_notify_push_url(@repository.id) %>" readonly="">
+
+  <button id="btn" data-clipboard-target="#notify_url">
+    <i class="fa fa-copy" alt="Copy to clipboard"></i>
+  </button>
 <% end %>
 
 <p><strong> <%= t('repository.show.date_processing') %>: </strong></p>
@@ -81,9 +83,14 @@
     <div id="metric_results"><%= image_tag 'loader.gif' %> <%= t('repository.show.loading') %></div>
   </div>
 </div>
+
+<!-- Copy to clipboard -->
+<%= javascript_include_tag "https://cdn.rawgit.com/zenorocha/clipboard.js/v1.5.10/dist/clipboard.min.js" %>
+
 <script type="text/javascript">
     $(document).ready(function () {
-      (new Repository.State(<%= @repository.id %>)).poll_state('')
+      (new Repository.State(<%= @repository.id %>)).poll_state('');
+      new Clipboard('#btn');
     });
 
   //Loads the accordion

--- a/app/views/repositories/show.html.erb
+++ b/app/views/repositories/show.html.erb
@@ -37,6 +37,13 @@
   <%= @kalibro_configuration.name %>
 </p>
 
+<% if repository_owner? @repository.id %>
+  <p>
+    <strong><%= t('repository.show.notify_push_url') %>:</strong>
+    <%= repository_notify_push_url(@repository.id) %>
+  </p>
+<% end %>
+
 <p><strong> <%= t('repository.show.date_processing') %>: </strong></p>
 
 <%= form_tag(repository_state_with_date_path(@repository.id), method: "get", remote: true) do %>

--- a/config/locales/views/repository/en.yml
+++ b/config/locales/views/repository/en.yml
@@ -38,3 +38,4 @@ en:
       metric_results: "Tree Metric Results"
       loading: "Loading data. Please, wait."
       date_processing: "Retrieve the closest processing information from"
+      notify_push_url: 'Notify Push Url for Gitlab'

--- a/config/locales/views/repository/pt.yml
+++ b/config/locales/views/repository/pt.yml
@@ -38,3 +38,4 @@ pt:
       metric_results: "Resultados de Métrica"
       loading: "Carregando os dados. Por favor, aguarde."
       date_processing: "Obtenha a informação de processamento mais próxima a"
+      notify_push_url: 'Url para notificações do Gitlab'

--- a/features/repository/show/repository_info.feature
+++ b/features/repository/show/repository_info.feature
@@ -19,6 +19,7 @@ Feature: Show Repository
     And I should see "Description"
     And I should see "License"
     And I should see the given repository's content
+    And I should not see "Notify Push Url for Gitlab"
 
   @kalibro_configuration_restart @kalibro_processor_restart @javascript
   Scenario: With a ready processing and asking to reprocess
@@ -32,6 +33,7 @@ Feature: Show Repository
     And I wait up for a ready processing
     When I visit the repository show page
     Then I should see the sample repository name
+    And I should see the correct notify push url
     And I should see "State"
     And I should see "Creation Date"
     And I should see "PREPARING time"

--- a/features/step_definitions/repository_steps.rb
+++ b/features/step_definitions/repository_steps.rb
@@ -281,3 +281,8 @@ end
 Then(/^I should get a not found error$/) do
   expect(page.driver.status_code).to eq(404)
 end
+
+Then(/^I should see the correct notify push url$/) do
+  step "I should see \"Notify Push Url for Gitlab\""
+  expect(page).to have_selector("input[value=\"#{repository_notify_push_url(host: Capybara.current_session.server.host, port: Capybara.current_session.server.port, locale: :en, id: @repository.id)}\"]")
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -86,4 +86,4 @@ Cucumber::Rails::Database.javascript_strategy = :truncation
 require 'kalibro_client/kalibro_cucumber_helpers/hooks.rb'
 
 Warden.test_mode!
-World(Warden::Test::Helpers, HeaderUtils, TableUtils)
+World(Warden::Test::Helpers, HeaderUtils, TableUtils, ActionView::Helpers::UrlHelper)

--- a/spec/controllers/repositories_controller_spec.rb
+++ b/spec/controllers/repositories_controller_spec.rb
@@ -556,5 +556,15 @@ describe RepositoriesController, :type => :controller do
 
       it { is_expected.to respond_with(:not_found) }
     end
+
+    context 'with an invalid request' do
+      before :each do
+        Repository.expects(:find).with(repository.id).returns(repository)
+        Webhooks::GitLab.any_instance.expects(:valid_request?).returns(false)
+        post_push
+      end
+
+      it { is_expected.to respond_with(:unprocessable_entity) }
+    end
   end
 end


### PR DESCRIPTION
Expose, for the repository's owner, the url he/she can use for push notifications on gitlab webhooks.

Also includes coverage for a case `RepositoryController#notify_push` that was missing.