### PR TITLE
Hide repositories

### DIFF
--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -14,7 +14,7 @@ class RepositoriesController < ApplicationController
   skip_before_action :verify_authenticity_token, :only => [:notify_push]
 
   def index
-    @repositories = Repository.all
+    @repositories = Repository.public_or_owned_by_user(current_user)
   end
 
   # GET /projects/1/repositories/1

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -1,6 +1,8 @@
 class Repository < KalibroClient::Entities::Processor::Repository
   include KalibroRecord
 
+  attr_writer :attributes
+
   def self.public_or_owned_by_user(user = nil)
     repository_attributes = RepositoryAttributes.where(public: true)
     repository_attributes += RepositoryAttributes.where(user_id: user.id, public: false) if user
@@ -16,5 +18,9 @@ class Repository < KalibroClient::Entities::Processor::Repository
 
   def self.latest(count=1)
     all.sort { |one, another| another.id <=> one.id }.first(count)
+  end
+
+  def attributes
+    @attributes ||= RepositoryAttributes.find_by_repository_id(@id)
   end
 end

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -1,6 +1,19 @@
 class Repository < KalibroClient::Entities::Processor::Repository
   include KalibroRecord
 
+  def self.public_or_owned_by_user(user = nil)
+    repository_attributes = RepositoryAttributes.where(public: true)
+    repository_attributes += RepositoryAttributes.where(user_id: user.id, public: false) if user
+
+    repository_attributes.map do |attribute|
+      begin
+        self.find(attribute.repository_id)
+      rescue Likeno::Errors::RecordNotFound
+        nil
+      end
+    end.compact
+  end
+
   def self.latest(count=1)
     all.sort { |one, another| another.id <=> one.id }.first(count)
   end

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -17,7 +17,7 @@ class Repository < KalibroClient::Entities::Processor::Repository
   end
 
   def self.latest(count=1)
-    all.sort { |one, another| another.id <=> one.id }.first(count)
+    all.sort { |one, another| another.id <=> one.id }.select { |repository| repository.attributes.public }.first(count)
   end
 
   def attributes

--- a/db/migrate/20160418192431_add_public_to_repository_attributes.rb
+++ b/db/migrate/20160418192431_add_public_to_repository_attributes.rb
@@ -1,0 +1,5 @@
+class AddPublicToRepositoryAttributes < ActiveRecord::Migration
+  def change
+    add_column :repository_attributes, :public, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151106182639) do
-
-  # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+ActiveRecord::Schema.define(version: 20160418192431) do
 
   create_table "kalibro_configuration_attributes", force: :cascade do |t|
     t.integer  "user_id"
@@ -44,11 +41,12 @@ ActiveRecord::Schema.define(version: 20151106182639) do
   create_table "repository_attributes", force: :cascade do |t|
     t.integer  "repository_id"
     t.integer  "user_id"
-    t.datetime "created_at",    null: false
-    t.datetime "updated_at",    null: false
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
+    t.boolean  "public",        default: true
   end
 
-  add_index "repository_attributes", ["user_id"], name: "index_repository_attributes_on_user_id", using: :btree
+  add_index "repository_attributes", ["user_id"], name: "index_repository_attributes_on_user_id"
 
   create_table "users", force: :cascade do |t|
     t.string   "name",                   limit: 255, default: "", null: false
@@ -66,7 +64,7 @@ ActiveRecord::Schema.define(version: 20151106182639) do
     t.string   "last_sign_in_ip",        limit: 255
   end
 
-  add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
-  add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
+  add_index "users", ["email"], name: "index_users_on_email", unique: true
+  add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
 
 end

--- a/features/repository/index.feature
+++ b/features/repository/index.feature
@@ -19,8 +19,9 @@ Feature: Repository listing
     And I have a sample repository
     And I have a sample project
     And I have a sample repository within the sample project
+    And I own that repository
     And I am at the All Repositories page
-    Then the sample repository should be there
+    Then the sample repository should not be there
     And the project repository should be there
     And I should not see "You must be logged in to create new Repositories."
 

--- a/features/step_definitions/repository_steps.rb
+++ b/features/step_definitions/repository_steps.rb
@@ -249,6 +249,10 @@ Then(/^the sample repository should be there$/) do
   expect(page).to have_content(@independent_repository.description)
 end
 
+Then(/^the sample repository should not be there$/) do
+  expect(page).to_not have_content(@independent_repository.name)
+end
+
 Then(/^the project repository should be there$/) do
   expect(page).to have_content(@repository.name)
   expect(page).to have_content(@repository.description)

--- a/spec/controllers/repositories_controller_spec.rb
+++ b/spec/controllers/repositories_controller_spec.rb
@@ -5,7 +5,7 @@ describe RepositoriesController, :type => :controller do
     let!(:repository) { FactoryGirl.build(:repository) }
 
     before :each do
-      Repository.expects(:all).returns([repository])
+      Repository.expects(:public_or_owned_by_user).returns([repository])
       get :index
     end
 

--- a/spec/factories/repository_attributes.rb
+++ b/spec/factories/repository_attributes.rb
@@ -1,6 +1,11 @@
 FactoryGirl.define do
   factory :repository_attributes do
+    self.public true
     association :user, strategy: :build
     association :repository, strategy: :build
+
+    trait :private do
+      self.public false
+    end
   end
 end

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -31,20 +31,43 @@ describe Repository do
 
   describe 'class method' do
     describe 'latest' do
-      let!(:repository) { FactoryGirl.build(:repository, id: 1) }
-      let!(:another_repository) { FactoryGirl.build(:another_repository, id: 2) }
+      let!(:repository) { FactoryGirl.build(:repository) }
+      let!(:another_repository) { FactoryGirl.build(:repository, id: 2) }
+      let!(:repository_attributes) { FactoryGirl.build(:repository_attributes) }
 
-      before do
-        Repository.expects(:all).returns([repository, another_repository])
+      before :each do
+        repository.expects(:attributes).returns(repository_attributes)
+        another_repository.expects(:attributes).returns(repository_attributes)
       end
 
-      it 'should return the two repositorys ordered' do
-        expect(Repository.latest(2)).to eq([another_repository, repository])
+      context 'without private repositories' do
+        before :each do
+          Repository.expects(:all).returns([repository, another_repository])
+        end
+
+        it 'is expected to return the two repositories ordered' do
+          expect(Repository.latest(2)).to eq([another_repository, repository])
+        end
+
+        context 'when no parameter is passed' do
+          it 'is expected to return just the most recent repository' do
+            expect(Repository.latest).to eq([another_repository])
+          end
+        end
       end
 
-      context 'when no parameter is passed' do
-        it 'should return just the most recent repository' do
-          expect(Repository.latest).to eq([another_repository])
+      context 'with private repositories' do
+        let(:private_repository) { FactoryGirl.build(:repository, id: 3) }
+        let(:private_attributes) { FactoryGirl.build(:repository_attributes, :private) }
+
+        before :each do
+          private_repository.expects(:attributes).returns(private_attributes)
+
+          Repository.expects(:all).returns([repository, another_repository, private_repository])
+        end
+
+        it 'is expected to return only the public ones' do
+          expect(Repository.latest(2)).to eq([another_repository, repository])
         end
       end
     end

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -20,5 +20,62 @@ describe Repository do
         end
       end
     end
+
+    describe 'public_or_owned_by_user' do
+      let!(:user) { FactoryGirl.build(:user, :with_id) }
+
+      let!(:owned_private_attrs)     { FactoryGirl.build(:repository_attributes, :private, user_id: user.id) }
+      let!(:owned_public_attrs)      { FactoryGirl.build(:repository_attributes,           user_id: user.id) }
+      let!(:not_owned_private_attrs) { FactoryGirl.build(:repository_attributes, :private, user_id: user.id + 1) }
+      let!(:not_owned_public_attrs)  { FactoryGirl.build(:repository_attributes,           user_id: user.id + 1) }
+
+      let!(:public_attrs) { [owned_public_attrs, not_owned_public_attrs] }
+      let(:public_repositories) { public_attrs.map(&:repository) }
+
+      let!(:owned_or_public_attrs) { public_attrs + [owned_private_attrs] }
+      let!(:owned_or_public_repositories) { owned_or_public_attrs.map(&:repository) }
+
+      let(:all_repositories) { owned_or_public_repositories + [not_owned_private_attrs.repository] }
+
+      context 'when repositories exist' do
+        before :each do
+          all_repositories.each do |repository|
+            described_class.stubs(:find).with(repository.id).returns(repository)
+          end
+
+          RepositoryAttributes.expects(:where).with(public: true).returns(public_attrs)
+        end
+
+        context 'when user is not provided' do
+          it 'is expected to find all public repositories' do
+            expect(described_class.public_or_owned_by_user).to eq(public_repositories)
+          end
+        end
+
+        context 'when user is provided' do
+          before do
+            RepositoryAttributes.expects(:where).with(user_id: user.id, public: false).returns([owned_private_attrs])
+          end
+
+          it 'is expected to find all public and owned repositories' do
+            expect(described_class.public_or_owned_by_user(user)).to eq(owned_or_public_repositories)
+          end
+        end
+      end
+
+      context 'when no repositories exist' do
+        before :each do
+          all_repositories.each do |repository|
+            described_class.stubs(:find).with(repository.id).raises(Likeno::Errors::RecordNotFound)
+          end
+
+          RepositoryAttributes.expects(:where).with(public: true).returns(public_attrs)
+        end
+
+        it 'is expected to be empty' do
+          expect(described_class.public_or_owned_by_user).to be_empty
+        end
+      end
+    end
   end
 end

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -1,6 +1,34 @@
 require 'rails_helper'
 
 describe Repository do
+  describe 'methods' do
+    describe 'attributes' do
+      subject { FactoryGirl.build(:repository) }
+
+      context 'when there are attributes' do
+        let!(:repository_attributes) { FactoryGirl.build(:repository_attributes) }
+
+        before :each do
+          RepositoryAttributes.expects(:find_by_repository_id).returns(repository_attributes)
+        end
+
+        it 'is expected to return the repository attributes' do
+          expect(subject.attributes).to eq(repository_attributes)
+        end
+      end
+
+      context 'when there are no attributes' do
+        before :each do
+          RepositoryAttributes.expects(:find_by_repository_id).returns(nil)
+        end
+
+        it 'is expected to return the repository attributes' do
+          expect(subject.attributes).to be_nil
+        end
+      end
+    end
+  end
+
   describe 'class method' do
     describe 'latest' do
       let!(:repository) { FactoryGirl.build(:repository, id: 1) }


### PR DESCRIPTION
This adds the functionality of hiding repositories that may be useful for not showing test repositories and the like.

This was needed since now repositories do not depend on projects to be created.