### PR TITLE
Update travis yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,13 @@ addons:
 before_script:
   - git clone https://github.com/mezuro/kalibro_install.git -b v4.0 kalibro_install
   - pushd kalibro_install
-    # Remove bugged libzmq3 package, see https://github.com/travis-ci/travis-ci/issues/982 and https://github.com/travis-ci/travis-ci/issues/1715 for details
+  #
+  # Remove bugged libzmq3 package, see https://github.com/travis-ci/travis-ci/issues/982 and https://github.com/travis-ci/travis-ci/issues/1715 for details
+  #
+  # In 2016/04/27 the state is:
+  #   * The first issue has been closed and apparently fixed by a PR
+  #   * The second one has been closed without a PR and removing the workaround below breaks the build
+  #
   - sudo apt-get remove libzmq3
   - bash install.sh
   - popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ addons:
   postgresql: "9.3"
 
 before_script:
-  #FIXME: change the branch to a newly installed version
-  - git clone https://github.com/mezuro/kalibro_install.git -b do_not_start_services kalibro_install
+  - git clone https://github.com/mezuro/kalibro_install.git -b v4.2 kalibro_install
   - export KALIBRO_CONFIGURATIONS_START=0
   - export KALIBRO_PROCESSOR_START=0
   - pushd kalibro_install

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,10 @@ addons:
   postgresql: "9.3"
 
 before_script:
-  - git clone https://github.com/mezuro/kalibro_install.git -b v4.0 kalibro_install
+  #FIXME: change the branch to a newly installed version
+  - git clone https://github.com/mezuro/kalibro_install.git -b do_not_start_services kalibro_install
+  - export KALIBRO_CONFIGURATIONS_START=0
+  - export KALIBRO_PROCESSOR_START=0
   - pushd kalibro_install
   #
   # Remove bugged libzmq3 package, see https://github.com/travis-ci/travis-ci/issues/982 and https://github.com/travis-ci/travis-ci/issues/1715 for details
@@ -18,14 +21,24 @@ before_script:
   - bash install.sh
   - popd
   - cp config/database.yml.sample config/database.yml
-  - bundle exec rake db:setup
+  # Do not run setup as the Kalibro services are up and this is not even necessary!
+  - bundle exec rake db:create
+  - bundle exec rake db:migrate
   - cp features/support/kalibro_cucumber_helpers.yml.sample features/support/kalibro_cucumber_helpers.yml
   - export BUNDLE_GEMFILE=$PWD/Gemfile
   - export CODECLIMATE_REPO_TOKEN=045c2433d496f108c0c6afa5516a72ddbfb1868fb34bf7a9bd095b7a0ea34a79
 
 script:
+  # Unit tests
   - bundle exec rake spec
   - bundle exec rake konacha:run
+  #
+  # Start kalibro for acceptance tests
+  - pushd kalibro_install
+  - bash start_kalibro_services.sh
+  - popd
+  #
+  # Acceptance tests
   - bundle exec rake cucumber
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: ruby
 rvm:
   - 2.3.0
+  - 2.0.0-p598 # CentOS 7
+  - 2.1.5 # Debian 8
+
 addons:
   postgresql: "9.3"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ before_script:
   - pushd kalibro_install
     # Remove bugged libzmq3 package, see https://github.com/travis-ci/travis-ci/issues/982 and https://github.com/travis-ci/travis-ci/issues/1715 for details
   - sudo apt-get remove libzmq3
-  - export KALIBRO_PROCESSOR_VERSION=v1.2.1
-  - export KALIBRO_CONFIGURATIONS_VERSION=v2.0.0
   - bash install.sh
   - popd
   - cp config/database.yml.sample config/database.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ rvm:
 addons:
   postgresql: "9.3"
 
+before_install:
+  - if ruby --version | cut -d ' ' -f 2 | grep -q 2.1.5p273 ; then gem update --system 2.4.8; fi
+
 before_script:
   - git clone https://github.com/mezuro/kalibro_install.git -b v4.2 kalibro_install
   - export KALIBRO_CONFIGURATIONS_START=0

--- a/CHANGELOG.rdoc
+++ b/CHANGELOG.rdoc
@@ -13,10 +13,13 @@ Prezento is the web interface for Mezuro.
 * Pluralize navigation menu links
 * Add missing translation for CompoundMetric
 * Make Compound Metric Config. metric list not include Hotspot metrics
-* Fix 'Tree Metrics' and 'Hotspot Metrics' PT translations in Configuration show view  
+* Fix 'Tree Metrics' and 'Hotspot Metrics' PT translations in Configuration show view
 * Show the notify push url for the repository's owner (Gitlab only)
 * Support for hiding repositories
 * Fix home latest content caching effectiveness
+* Update travis script
+* Support for ruby 2.0.0-p598 (CentOS 7 default) and 2.1.5 (Debian 8 default)
+* Make Travis fail if minimun unit test coverage is below 100%
 
 == v0.11.3 - 01/04/2016
 

--- a/features/support/header.rb
+++ b/features/support/header.rb
@@ -10,6 +10,9 @@ module HeaderUtils
   end
 
   def set_headers(headers)
-    headers.each(&method(:set_header))
+    # The call 'headers.each(&method(:set_header))' breaks on ruby 2.0.0-p598, which is the
+    # default version on CentOS 7. When that SO updates ruby, this should be reverted to
+    # the more concise syntax.
+    headers.each { |key, value| method(:set_header).call(key, value) }
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,17 +3,15 @@ require "codeclimate-test-reporter"
 CodeClimate::TestReporter.start
 require 'simplecov'
 
-SimpleCov.start do
+SimpleCov.start 'rails' do
+  # Minimum coverage is only desired on CI tools when building the environment. CI is a
+  # default environment variable used by Travis. For reference, see here:
+  # https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables
+  minimum_coverage 100 if ENV["CI"] == 'true'
   coverage_dir 'coverage/rspec'
-
-  add_group "Models", "app/models"
-  add_group "Controllers", "app/controllers"
-  add_group "Helpers", "app/helpers"
-  add_group "Mailers", "app/mailers"
 
   add_filter "/spec/"
   add_filter "/features/"
-  add_filter "/config/"
 end
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'


### PR DESCRIPTION
Include builds using ruby 2.0.0-p598 and 2.1.5, CentOS 7 and Debian 8 default versions respectively.
Remove unnecessary configurations.
Make Travis fail if unit test coverage is below 100%.

This closes https://github.com/mezuro/prezento/issues/351 and https://github.com/mezuro/prezento/issues/352