### PR TITLE
Load Kalibro service addresses from file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ before_script:
   - bash install.sh
   - popd
   - cp config/database.yml.sample config/database.yml
+  - cp config/kalibro.yml.sample config/kalibro.yml
   # Do not run setup as the Kalibro services are up and this is not even necessary!
   - bundle exec rake db:create
   - bundle exec rake db:migrate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Prezento is the web interface for Mezuro.
 
 The version numbers below try to follow the conventions at http://semver.org/.
 
+## Unreleased
+
+- Always load Kalibro service addresses from file
+
 ## v1.0.1 - 11/05/2016
 
 - Fix kalibro services address init under production

--- a/bin/setup
+++ b/bin/setup
@@ -25,6 +25,7 @@ Dir.chdir APP_ROOT do
   unless File.exist?("config/database.yml")
     run "cp config/database.yml.sample config/database.yml"
     run "cp features/support/kalibro_cucumber_helpers.yml.sample features/support/kalibro_cucumber_helpers.yml"
+    run "cp config/kalibro.yml.sample config/kalibro.yml"
   end
 
   puts "\n== Preparing database ==".green

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -44,4 +44,7 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Kalibro URL
+  Likeno.configure_with(Rails.root.join('config', 'kalibro.yml'))
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -45,4 +45,7 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Kalibro URL
+  Likeno.configure_with(Rails.root.join('config', 'kalibro.yml'))
 end

--- a/config/kalibro.yml.sample
+++ b/config/kalibro.yml.sample
@@ -1,0 +1,2 @@
+processor_address: "http://localhost:8082"
+configurations_address: "http://localhost:8083"


### PR DESCRIPTION
This makes explicit that this is configurable and will be more packaging
friendly as the configuration file will get linked from /etc.

Signed-off-by: Eduardo Araújo <duduktamg@hotmail.com>