### PR TITLE
Changes 'kalibro_errors' to use 'likeno_errors'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The version numbers below try to follow the conventions at http://semver.org/.
 
 ## Unreleased
 
+- Fix warnings about 'prezento_errors'
+
 ## v1.1.0 - 01/06/2016
 
 - Always load Kalibro service addresses from file

--- a/app/controllers/base_metric_configurations_controller.rb
+++ b/app/controllers/base_metric_configurations_controller.rb
@@ -65,7 +65,7 @@ class BaseMetricConfigurationsController < ApplicationController
   end
 
   def failed_action(format, error = nil)
-    errors = @metric_configuration.kalibro_errors
+    errors = @metric_configuration.likeno_errors
     errors << error unless error.nil?
 
     flash[:notice] = errors.join(', ')

--- a/app/controllers/kalibro_configurations_controller.rb
+++ b/app/controllers/kalibro_configurations_controller.rb
@@ -82,7 +82,7 @@ class KalibroConfigurationsController < ApplicationController
       format.json { render action: 'show', status: :created, location: @kalibro_configuration }
     else
       format.html { render action: 'new' }
-      format.json { render json: @kalibro_configuration.kalibro_errors, status: :unprocessable_entity }
+      format.json { render json: @kalibro_configuration.likeno_errors, status: :unprocessable_entity }
     end
   end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -81,7 +81,7 @@ class ProjectsController < ApplicationController
       format.json { render action: 'show', status: :created, location: @project }
     else
       format.html { render action: 'new' }
-      format.json { render json: @project.kalibro_errors, status: :unprocessable_entity }
+      format.json { render json: @project.likeno_errors, status: :unprocessable_entity }
     end
   end
 end

--- a/app/controllers/reading_groups_controller.rb
+++ b/app/controllers/reading_groups_controller.rb
@@ -73,7 +73,7 @@ class ReadingGroupsController < ApplicationController
       format.json { render action: 'show', status: :created, location: @reading_group }
     else
       format.html { render action: 'new' }
-      format.json { render json: @reading_group.kalibro_errors, status: :unprocessable_entity }
+      format.json { render json: @reading_group.likeno_errors, status: :unprocessable_entity }
     end
   end
 end

--- a/app/controllers/readings_controller.rb
+++ b/app/controllers/readings_controller.rb
@@ -56,7 +56,7 @@ class ReadingsController < ApplicationController
   # Duplicated code on create and update actions extracted here
   def failed_action(format, destiny_action)
     format.html { render action: destiny_action }
-    format.json { render json: @reading.kalibro_errors, status: :unprocessable_entity }
+    format.json { render json: @reading.likeno_errors, status: :unprocessable_entity }
   end
 
   # Code extracted from create action

--- a/app/views/shared/_form_errors.html.erb
+++ b/app/views/shared/_form_errors.html.erb
@@ -1,9 +1,9 @@
-<% if object.kalibro_errors.any? %>
+<% if object.likeno_errors.any? %>
   <div id="error_explanation">
-    <h2><%= pluralize(object.kalibro_errors.count, "error") %> prohibited this <%= object.class.to_s %> from being saved:</h2>
+    <h2><%= pluralize(object.likeno_errors.count, "error") %> prohibited this <%= object.class.to_s %> from being saved:</h2>
 
     <ul>
-    <% object.kalibro_errors.each do |msg| %>
+    <% object.likeno_errors.each do |msg| %>
       <li><%= msg %></li>
     <% end %>
     </ul>


### PR DESCRIPTION
The change fixes deprecated warnings about "prezento_errors".