### PR TITLE
Sets project image on attribute creation (closes #264)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The version numbers below try to follow the conventions at http://semver.org/.
 ## Unreleased
 
 - Remove the repository's instance that has remained in the db
+- Adds repository image on project attribute creation
 - Adding translation of the periodicity options in repository helper
 - Fixing wrong configurations translation in portuguese navbar
 - Fix warnings about 'prezento_errors'

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -4,12 +4,16 @@ class ProjectsController < ApplicationController
   before_action :authenticate_user!,
     except: [:index, :show]
   before_action :project_owner?, only: [:edit, :update, :destroy]
+  before_action :fetch_image_url, only: [:create, :update]
 
   # GET /projects/new
   def new
     @project = Project.new
   end
 
+  def fetch_image_url
+    @image_url = project_params.delete(:image_url)
+  end
   # GET /projects
   # GET /projects.json
   def index
@@ -19,7 +23,6 @@ class ProjectsController < ApplicationController
   # POST /projects
   # POST /projects.json
   def create
-    @image_url = project_params.delete(:image_url)
     @project = Project.new(project_params)
     respond_to do |format|
       create_and_redir(format)
@@ -41,8 +44,7 @@ class ProjectsController < ApplicationController
 
   def update
     set_project
-    image_url = project_params.delete(:image_url)
-    if @project.update(project_params) && @project.attributes.update(image_url: image_url)
+    if @project.update(project_params) && @project.attributes.update(image_url: @image_url)
       redirect_to(project_path(@project.id))
     else
       render "edit"

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -19,11 +19,10 @@ class ProjectsController < ApplicationController
   # POST /projects
   # POST /projects.json
   def create
-    image_url = project_params.delete(:image_url)
+    @image_url = project_params.delete(:image_url)
     @project = Project.new(project_params)
     respond_to do |format|
       create_and_redir(format)
-      @project.attributes.update(image_url: image_url) unless @project.attributes.nil?
     end
   end
 
@@ -76,7 +75,7 @@ class ProjectsController < ApplicationController
   # Extracted code from create action
   def create_and_redir(format)
     if @project.save
-      current_user.project_attributes.create(project_id: @project.id)
+      current_user.project_attributes.create(project_id: @project.id, image_url: @image_url)
       format.html { redirect_to project_path(@project.id), notice: t('successfully_created', :record => t(@project.class.name)) }
       format.json { render action: 'show', status: :created, location: @project }
     else

--- a/features/project/create.feature
+++ b/features/project/create.feature
@@ -14,6 +14,7 @@ Feature: Project Creation
     And I am at the New Project page
     And I fill the Name field with "Kalibro"
     And I fill the Description field with "Web Service to collect metrics"
+    And I insert the url on the image field
     When I press the Save button
     Then I should see "Kalibro"
     And I should see "Web Service to collect metrics"

--- a/features/step_definitions/project_steps.rb
+++ b/features/step_definitions/project_steps.rb
@@ -81,3 +81,7 @@ end
 Then(/^The field "(.*?)" should be filled with the sample project "(.*?)"$/) do |field, value|
   expect(page.find_field(field).value).to eq(@project.send(value))
 end
+
+Then(/^I insert the url on the image field/) do
+  fill_in "project_image_url", with: "https://www.nasa.gov/sites/default/files/styles/image_card_4x3_ratio/public/thumbnails/image/leisa_christmas_false_color.png?itok=Jxf0IlS4"
+end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -14,7 +14,8 @@ describe ProjectsController, :type => :controller do
 
   describe 'create' do
     before do
-      sign_in FactoryGirl.create(:user)
+      @user = FactoryGirl.create(:user)
+      sign_in @user
     end
 
     context 'with valid fields' do
@@ -26,11 +27,15 @@ describe ProjectsController, :type => :controller do
       end
 
       context 'rendering the show' do
-        before :each do
-          post :create, :project => subject_params
-        end
 
+        subject { post :create, :project => subject_params }
+
+        it 'should increase total number of project_attributes' do
+          expect{subject}.to change{@user.project_attributes.count}.by(1)
+        end
+          
         it 'should redirect to the show view' do
+          subject
           expect(response).to redirect_to project_path(project.id)
         end
       end
@@ -56,6 +61,7 @@ describe ProjectsController, :type => :controller do
       end
 
       it { is_expected.to render_template(:new) }
+
     end
   end
 


### PR DESCRIPTION
- Uses 'image_url' as instance variable to be able to set 'image_url'
- It evades the problem of updating the image of a null 'project_attribute' on repository creation
