### PR TITLE
Create tmp folder on setup script

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -40,6 +40,9 @@ Dir.chdir APP_ROOT do
   run 'bin/rake log:clear'
   run 'bin/rake tmp:clear'
 
+  puts "\n== Creating tempfiles  =="
+  run 'bin/rake tmp:create'
+
   puts "\n== Restarting application server ==".green
   run "touch tmp/restart.txt"
 end


### PR DESCRIPTION
Fix the problem of setup script trying to create the restart.txt without a tmp folder.