### PR TITLE
Refactor a few modules to use has_owner concern

### DIFF
--- a/app/models/concerns/has_owner.rb
+++ b/app/models/concerns/has_owner.rb
@@ -1,0 +1,21 @@
+require 'active_support/concern'
+
+module HasOwner
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def public_or_owned_by_user(user = nil)
+      class_name = name+"Attributes"
+      collection = class_name.constantize.where(public: true)
+      collection += class_name.constantize.where(user_id: user.id, public: false) if user
+
+      collection.map do |item|
+        begin
+          self.find(item.send(name.underscore+"_id"))
+        rescue Likeno::Errors::RecordNotFound
+          nil
+        end
+      end.compact
+    end
+  end
+end

--- a/app/models/kalibro_configuration.rb
+++ b/app/models/kalibro_configuration.rb
@@ -1,19 +1,8 @@
 class KalibroConfiguration < KalibroClient::Entities::Configurations::KalibroConfiguration
   include KalibroRecord
+  include HasOwner
+
   attr_writer :attributes
-
-  def self.public_or_owned_by_user(user=nil)
-    kalibro_configuration_attributes = KalibroConfigurationAttributes.where(public: true)
-    kalibro_configuration_attributes += KalibroConfigurationAttributes.where(user_id: user.id, public: false) if user
-
-    kalibro_configuration_attributes.map { |kalibro_configuration_attribute|
-      begin
-        self.find(kalibro_configuration_attribute.kalibro_configuration_id)
-      rescue Likeno::Errors::RecordNotFound
-        nil
-      end
-    }.compact
-  end
 
   def self.public
     self.public_or_owned_by_user

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,20 +1,8 @@
 class Project < KalibroClient::Entities::Processor::Project
   include KalibroRecord
+  include HasOwner
 
   attr_writer :attributes
-
-  def self.public_or_owned_by_user(user = nil)
-    project_attributes = ProjectAttributes.where(public: true)
-    project_attributes += ProjectAttributes.where(user_id: user.id, public: false) if user
-
-    project_attributes.map do |attribute|
-      begin
-        self.find(attribute.project_id)
-      rescue Likeno::Errors::RecordNotFound
-        nil
-      end
-    end.compact
-  end
 
   def self.latest(count = 1)
     all.sort { |one, another| another.id <=> one.id }.select { |project|

--- a/app/models/reading_group.rb
+++ b/app/models/reading_group.rb
@@ -1,19 +1,8 @@
 class ReadingGroup < KalibroClient::Entities::Configurations::ReadingGroup
   include KalibroRecord
+  include HasOwner
+
   attr_writer :attributes
-
-  def self.public_or_owned_by_user(user=nil)
-    reading_group_attributes = ReadingGroupAttributes.where(public: true)
-    reading_group_attributes += ReadingGroupAttributes.where(user_id: user.id, public: false) if user
-
-    reading_group_attributes.map { |reading_group_attribute|
-      begin
-        self.find(reading_group_attribute.reading_group_id)
-      rescue Likeno::Errors::RecordNotFound
-        nil
-      end
-    }.compact
-  end
 
   def self.public
     self.public_or_owned_by_user

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -1,20 +1,8 @@
 class Repository < KalibroClient::Entities::Processor::Repository
   include KalibroRecord
+  include HasOwner
 
   attr_writer :attributes
-
-  def self.public_or_owned_by_user(user = nil)
-    repository_attributes = RepositoryAttributes.where(public: true)
-    repository_attributes += RepositoryAttributes.where(user_id: user.id, public: false) if user
-
-    repository_attributes.map do |attribute|
-      begin
-        self.find(attribute.repository_id)
-      rescue Likeno::Errors::RecordNotFound
-        nil
-      end
-    end.compact
-  end
 
   def self.latest(count=1)
     all.sort { |one, another| another.id <=> one.id }.select { |repository| repository.attributes.public }.first(count)


### PR DESCRIPTION
- Creates new concern call'd "HasOwner", that is usable in entities that belongs to users and can be private/public (for example: projects, repositories, and a few others)
- Refactor few classes to use the HasOwner concern - The classes are: "Project", "KalibroConfiguration", "ReadingGroup" and "Repository"
