### PR TITLE
Remove home link from navbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The version numbers below try to follow the conventions at http://semver.org/.
 - Fix warnings about 'prezento_errors'
 - Creates pattern for creation tooltips in Compound Metric Configuration
 - Update development Ruby target to 2.3.1
+- Remove redundant root path link from navbar
 
 ## v1.1.0 - 01/06/2016
 

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -12,7 +12,6 @@
         </div>
         <div class="collapse navbar-collapse" id="nav-collapse">
           <ul class="nav navbar-nav">
-            <li><%= link_to t('home'), root_path %></li>
             <li><%= link_to Project.model_name.human(count: 2), projects_path %></li>
             <li><%= link_to Repository.model_name.human(count: 2), repositories_path %></li>
             <li><%= link_to KalibroConfiguration.model_name.human(count: 2), kalibro_configurations_path %></li>

--- a/config/locales/views/layouts/en.yml
+++ b/config/locales/views/layouts/en.yml
@@ -1,6 +1,5 @@
 en:
   instant_loading_page: "Wait an instant while we are loading the page that you have requested."
-  home: "Home"
   edit_account: "Edit Account"
   sign_out: "Sign Out"
   sign_in: "Sign In"

--- a/config/locales/views/layouts/pt.yml
+++ b/config/locales/views/layouts/pt.yml
@@ -1,6 +1,5 @@
 pt:
   instant_loading_page: "Espere um instante enquanto estamos carregando a página que você solicitou."
-  home: "Início"
   edit_account: "Editar Conta"
   sign_out: "Sair"
   sign_in: "Entrar"


### PR DESCRIPTION
It is redundant with the logo link.

Part of https://github.com/mezuro/prezento/issues/366 and https://github.com/mezuro/prezento/pull/392.