### PR TITLE
Handling unsupported format requests with error page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -138,7 +138,7 @@ group :development, :test do
 end
 
 # Acceptance tests
-group :cucumber do
+group :cucumber, :test do
   gem 'cucumber-rails', '~> 1.4.0'
   # cleans the database
   gem 'database_cleaner', '~> 1.5.0'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,6 +12,7 @@ class ApplicationController < ActionController::Base
 
   rescue_from ActiveRecord::RecordNotFound, with: :not_found
   rescue_from Likeno::Errors::RecordNotFound, with: :not_found
+  rescue_from ActionView::MissingTemplate, with: :not_found
 
   class << self
     # This is necessary for correct devise routing with locales: https://github.com/plataformatec/devise/wiki/How-To:--Redirect-with-locale-after-authentication-failure
@@ -38,7 +39,7 @@ class ApplicationController < ActionController::Base
         format.json { head :not_found }
       end
     rescue ActionController::UnknownFormat
-      render status: 404, text: "The page you were looking for doesn't exist (404)"
+      render file: "#{Rails.root}/public/406", layout: false, status: :not_acceptable, formats: :html
     end
   end
 

--- a/public/406.html
+++ b/public/406.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>.<%= params[:format] %> is not a valid format</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <style>
+  body {
+    background-color: #EFEFEF;
+    color: #2E2F30;
+    text-align: center;
+    font-family: arial, sans-serif;
+    margin: 0;
+  }
+
+  div.dialog {
+    width: 95%;
+    max-width: 33em;
+    margin: 4em auto 0;
+  }
+
+  div.dialog > div {
+    border: 1px solid #CCC;
+    border-right-color: #999;
+    border-left-color: #999;
+    border-bottom-color: #BBB;
+    border-top: #B00100 solid 4px;
+    border-top-left-radius: 9px;
+    border-top-right-radius: 9px;
+    background-color: white;
+    padding: 7px 12% 0;
+    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+  }
+
+  h1 {
+    font-size: 100%;
+    color: #730E15;
+    line-height: 1.5em;
+  }
+
+  div.dialog > p {
+    margin: 0 0 1em;
+    padding: 1em;
+    background-color: #F7F7F7;
+    border: 1px solid #CCC;
+    border-right-color: #999;
+    border-left-color: #999;
+    border-bottom-color: #999;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    border-top-color: #DADADA;
+    color: #666;
+    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+  }
+  </style>
+</head>
+
+<body>
+  <!-- This file lives in public/404.html -->
+  <div class="dialog">
+    <div>
+      <h1>.<%= params[:format] %> is not a valid format</h1>
+    </div>
+    <p>If you are the application owner check the logs for more information.</p>
+  </div>
+</body>
+</html>

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -91,7 +91,7 @@ describe ProjectsController, :type => :controller do
           get :show, id: project.id, format: :txt
         end
 
-        it { is_expected.to respond_with(:not_found) }
+        it { is_expected.to respond_with(:not_acceptable) }
       end
     end
 


### PR DESCRIPTION
- Rescuing ActionView::MissingTemplate with `not_found` method located in `app/controllers/application_controller.rb`
- Modifying `not_found` method to render page telling that format given is unsupported
- Updating related tests

This PR closes #301