### PR TITLE
Puma server

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,9 @@ gem 'http_accept_language'
 # Routes for JS files
 gem 'js-routes', '~> 1.1.0'
 
+# Puma server
+gem 'puma'
+
 group :test do
   # Easier test writing
   gem "shoulda-matchers", '~> 2.8.0'
@@ -80,8 +83,6 @@ group :test do
   # Test coverage report
   gem 'codeclimate-test-reporter', require: nil
 
-  # For Konacha
-  gem 'thin'
 end
 
 # Startup script generation (server process manager)

--- a/Gemfile
+++ b/Gemfile
@@ -67,10 +67,14 @@ gem 'http_accept_language'
 # Routes for JS files
 gem 'js-routes', '~> 1.1.0'
 
-# Puma server
+# Use Puma webserver for the application.
 gem 'puma'
 
 group :test do
+
+  # Use Thin webserver for konacha tests.
+  gem 'thin'
+
   # Easier test writing
   gem "shoulda-matchers", '~> 2.8.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,7 @@ GEM
       mime-types (>= 1.16, < 3)
       nokogiri (~> 1.5)
       rails (>= 3, < 5)
+    daemons (1.2.3)
     dalli (2.7.4)
     database_cleaner (1.5.0)
     debug_inspector (0.0.2)
@@ -108,6 +109,7 @@ GEM
     domain_name (0.5.24)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
+    eventmachine (1.0.8)
     exception_notification (4.1.1)
       actionmailer (>= 3.0.4)
       activesupport (>= 3.0.4)
@@ -301,6 +303,10 @@ GEM
     therubyracer (0.12.2)
       libv8 (~> 3.16.14.0)
       ref
+    thin (1.6.4)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0, >= 1.0.4)
+      rack (~> 1.0)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.1)
@@ -380,6 +386,7 @@ DEPENDENCIES
   sprockets
   sqlite3
   therubyracer
+  thin
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,7 +93,6 @@ GEM
       mime-types (>= 1.16, < 3)
       nokogiri (~> 1.5)
       rails (>= 3, < 5)
-    daemons (1.2.3)
     dalli (2.7.4)
     database_cleaner (1.5.0)
     debug_inspector (0.0.2)
@@ -109,7 +108,6 @@ GEM
     domain_name (0.5.24)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
-    eventmachine (1.0.8)
     exception_notification (4.1.1)
       actionmailer (>= 3.0.4)
       activesupport (>= 3.0.4)
@@ -216,6 +214,7 @@ GEM
       cliver (~> 0.3.1)
       multi_json (~> 1.0)
       websocket-driver (>= 0.2.0)
+    puma (3.8.2)
     rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -302,10 +301,6 @@ GEM
     therubyracer (0.12.2)
       libv8 (~> 3.16.14.0)
       ref
-    thin (1.6.4)
-      daemons (~> 1.0, >= 1.0.9)
-      eventmachine (~> 1.0, >= 1.0.4)
-      rack (~> 1.0)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.1)
@@ -371,6 +366,7 @@ DEPENDENCIES
   mocha
   pg (~> 0.18.1)
   poltergeist (~> 1.7.0)
+  puma
   rails (= 4.2.4)
   rails-html-sanitizer (~> 1.0)
   railsstrap (~> 3.3.4)
@@ -384,10 +380,9 @@ DEPENDENCIES
   sprockets
   sqlite3
   therubyracer
-  thin
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0.0)
 
 BUNDLED WITH
-   1.11.2
+   1.14.6

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bundle exec rails s -p $PORT -e $RAILS_ENV
+web: bundle exec puma -C config/puma.rb

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,8 @@ module Mezuro
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+
+    require "#{Rails.root}/lib/core_extensions/rack/handler"
+
   end
 end

--- a/config/initializers/konacha.rb
+++ b/config/initializers/konacha.rb
@@ -7,26 +7,4 @@ if defined?(Konacha)
     config.stylesheets  = %w(application)
     config.driver = :poltergeist
   end
-
-  # Use thin to run Konacha tests. This is needed because the tests hang frequently in Travis using the default (WEBRick)
-  # We can't just do 'Capybara.server' in the configure block because it will also apply to anything else run by
-  # Capybara. So instead, override the Konacha.run method to change the server, and restore it after completion.
-  module Konacha
-    class << self
-      old_run = instance_method(:run)
-
-      define_method(:run) do
-        prev_server = Capybara.server
-        begin
-          Capybara.server do |app, port|
-            require 'rack/handler/thin'
-            Rack::Handler::Thin.run(app, :Port => port)
-          end
-          old_run.bind(self).call
-        ensure
-          Capybara.server(&prev_server)
-        end
-      end
-    end
-  end
 end

--- a/config/initializers/konacha.rb
+++ b/config/initializers/konacha.rb
@@ -7,4 +7,26 @@ if defined?(Konacha)
     config.stylesheets  = %w(application)
     config.driver = :poltergeist
   end
+
+  # Use Thin to run Konacha tests. This is needed because the tests hang frequently in Travis using the default (WEBRick)
+  # We can't just do 'Capybara.server' in the configure block because it will also apply to anything else run by
+  # Capybara. So instead, override the Konacha.run method to change the server, and restore it after completion.
+  module Konacha
+    class << self
+      old_run = instance_method(:run)
+
+      define_method(:run) do
+        prev_server = Capybara.server
+        begin
+          Capybara.server do |app, port|
+            require 'rack/handler/thin'
+            Rack::Handler::Thin.run(app, :Port => port)
+          end
+          old_run.bind(self).call
+        ensure
+          Capybara.server(&prev_server)
+        end
+      end
+    end
+  end
 end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,0 +1,15 @@
+workers Integer(ENV['WEB_CONCURRENCY'] || 2)
+threads_count = Integer(ENV['RAILS_MAX_THREADS'] || 5)
+threads threads_count, threads_count
+
+preload_app!
+
+rackup      DefaultRackup
+port        ENV['PORT']     || 3000
+environment ENV['RACK_ENV'] || 'development'
+
+on_worker_boot do
+  # Worker specific setup for Rails 4.1+
+  # See: https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#on-worker-boot
+  ActiveRecord::Base.establish_connection
+end

--- a/lib/core_extensions/rack/handler.rb
+++ b/lib/core_extensions/rack/handler.rb
@@ -1,0 +1,15 @@
+# Monkey Patch for Rack to choose Puma as the default webserver. 
+# Without this, Thin takes precedence over Puma.
+# Removing Thin would make this unnecessary. However, Thin is needed for Konacha.
+
+module Rack
+  require 'rack/handler/puma'
+
+  module Handler
+
+    def self.default argument
+      return Rack::Handler::Puma
+    end
+
+  end
+end

--- a/spec/lib/core_extensions/rack/handler_spec.rb
+++ b/spec/lib/core_extensions/rack/handler_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+require "#{Rails.root}/lib/core_extensions/rack/handler"
+
+RSpec.describe Rack::Handler do
+
+    describe 'default webserver' do
+        it 'should be puma' do
+            argument = 'argument'
+            expect(Rack::Handler.default argument).to eq(Rack::Handler::Puma)
+        end
+    end
+end


### PR DESCRIPTION
Install and configure Puma webserver, while still maintaing Thin.

Puma is used as the default webserver and Thin is used by Konacha, since Puma, just like WEBrick, hangs on Travis.

Related to issue #383.