### PR TITLE
Updating rubygems version for Ruby 2.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ addons:
 
 before_install:
   - if ruby --version | cut -d ' ' -f 2 | grep -q 2.1.5p273 ; then gem update --system 2.4.8; fi
+  - if ruby --version | cut -d ' ' -f 2 | grep -q 2.3.1p112 ; then gem update --system; fi
 
 before_script:
   - cp config/database.yml.sample config/database.yml

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -49,19 +49,19 @@ ActiveRecord::Schema.define(version: 20160418192431) do
   add_index "repository_attributes", ["user_id"], name: "index_repository_attributes_on_user_id"
 
   create_table "users", force: :cascade do |t|
-    t.string   "name",                   limit: 255, default: "", null: false
-    t.string   "email",                  limit: 255, default: "", null: false
+    t.string   "name",                   default: "", null: false
+    t.string   "email",                  default: "", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "encrypted_password",     limit: 255, default: "", null: false
-    t.string   "reset_password_token",   limit: 255
+    t.string   "encrypted_password",     default: "", null: false
+    t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",                      default: 0
+    t.integer  "sign_in_count",          default: 0
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.string   "current_sign_in_ip",     limit: 255
-    t.string   "last_sign_in_ip",        limit: 255
+    t.string   "current_sign_in_ip"
+    t.string   "last_sign_in_ip"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true


### PR DESCRIPTION
- Updating rubygems version for ruby 2.3.1 due to CI problems with these versions of ruby and rubygems 