### PR TITLE
Missing processing translation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ addons:
   postgresql: "9.3"
 
 before_install:
-  - gem update bundler
   - if ruby --version | cut -d ' ' -f 2 | grep -q 2.1.5p273 ; then gem update --system 2.4.8; fi
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,13 @@ rvm:
   - 2.3.1
   - 2.0.0-p598 # CentOS 7
   - 2.1.5 # Debian 8
-cache: bundler
+# cache: bundler
 
 addons:
   postgresql: "9.3"
 
 before_install:
+  - gem update bundler
   - if ruby --version | cut -d ' ' -f 2 | grep -q 2.1.5p273 ; then gem update --system 2.4.8; fi
 
 before_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The version numbers below try to follow the conventions at http://semver.org/.
 - Creates pattern for creation tooltips in Compound Metric Configuration
 - Update development Ruby target to 2.3.1
 - Remove redundant root path link from navbar
+- Adding translation of processing results
 
 ## v1.1.0 - 01/06/2016
 

--- a/app/views/repositories/_processing_information.html.erb
+++ b/app/views/repositories/_processing_information.html.erb
@@ -11,7 +11,7 @@
 <% unless @processing.process_times.nil? %>
   <% @processing.process_times.each do |process_time| %>
     <p>
-      <strong><%= process_time.state %> time:</strong>
+      <strong><%= t(process_time.state, :scope => 'activemodel.attributes.processing.state_names') %>:</strong>
       <%= humanize_elapsed_time(process_time.time) %>
     </p>
   <% end %>

--- a/config/locales/views/processing/en.yml
+++ b/config/locales/views/processing/en.yml
@@ -8,3 +8,12 @@ en:
       processing:
         state: "State"
         creation_date: "Creation Date"
+        state_names:
+          PREPARING: "Preparing Time"
+          DOWNLOADING: "Downloading Time"
+          COLLECTING: "Collecting Time"
+          CHECKING: "Checking Time"
+          BUILDING: "Building Time"
+          AGGREGATING: "Aggregating Time"
+          CALCULATING: "Calculating Time"
+          INTERPRETING: "Interpreting Time"

--- a/config/locales/views/processing/pt.yml
+++ b/config/locales/views/processing/pt.yml
@@ -8,3 +8,12 @@ pt:
       processing:
         state: "Estado"
         creation_date: "Data de Criação"
+        state_names:
+          PREPARING: "Tempo de Preparo"
+          DOWNLOADING: "Tempo de Download"
+          COLLECTING: "Tempo de Coleta"
+          CHECKING: "Tempo de Verificação"   
+          BUILDING: "Tempo de Construção"
+          AGGREGATING: "Tempo de Agregação"
+          CALCULATING: "Tempo de Cálculo"
+          INTERPRETING: "Tempo de Interpretação"

--- a/features/repository/show/independent.feature
+++ b/features/repository/show/independent.feature
@@ -16,7 +16,6 @@ Feature: Date Select
     Then I should see the sample repository name
     And I should see "State"
     And I should see "Creation Date"
-    And I should see "Creation Date"
     And I should see "Preparing Time"
     And I should see "Collecting Time"
     And I should see "Building Time"

--- a/features/repository/show/independent.feature
+++ b/features/repository/show/independent.feature
@@ -16,12 +16,13 @@ Feature: Date Select
     Then I should see the sample repository name
     And I should see "State"
     And I should see "Creation Date"
-    And I should see "PREPARING time"
-    And I should see "COLLECTING time"
-    And I should see "BUILDING time"
-    And I should see "AGGREGATING time"
-    And I should see "CALCULATING time"
-    And I should see "INTERPRETING time"
+    And I should see "Creation Date"
+    And I should see "Preparing Time"
+    And I should see "Collecting Time"
+    And I should see "Building Time"
+    And I should see "Aggregating Time"
+    And I should see "Calculating Time"
+    And I should see "Interpreting Time"
     When I click the "Tree Metric Results" h3
     And I click the "Modules Tree" h3
     Then I should see "Metric"

--- a/features/repository/show/repository_info.feature
+++ b/features/repository/show/repository_info.feature
@@ -36,12 +36,12 @@ Feature: Show Repository
     And I should see the correct notify push url
     And I should see "State"
     And I should see "Creation Date"
-    And I should see "PREPARING time"
-    And I should see "COLLECTING time"
-    And I should see "BUILDING time"
-    And I should see "AGGREGATING time"
-    And I should see "CALCULATING time"
-    And I should see "INTERPRETING time"
+    And I should see "Preparing Time"
+    And I should see "Collecting Time"
+    And I should see "Building Time"
+    And I should see "Aggregating Time"
+    And I should see "Calculating Time"
+    And I should see "Interpreting Time"
     When I click the "Tree Metric Results" h3
     And I click the "Modules Tree" h3
     Then I should see "Metric"

--- a/features/repository/show/repository_info.feature
+++ b/features/repository/show/repository_info.feature
@@ -74,5 +74,5 @@ Feature: Show Repository
     When I click the "Modules Tree" h3
     Then I should see "Loading data. Please, wait."
     And I wait for "75" seconds or until I see "COLLECTING"
-    And I wait for "120" seconds or until I see "AGGREGATING"
+    And I wait for "120" seconds or until I see "Aggregating Time"
     And I wait for "400" seconds or until I see "READY"


### PR DESCRIPTION
Fix the problem related to issue #312 

- Insertion of processing state translations

- Changing the variable in the i18n syntax

- Changing the corresponding tests

- Correction of the error present in the bundler when calling the cucumber that caused a failure to load in the Travis