### PR TITLE
Creating tests for text format requests

### DIFF
--- a/spec/controllers/kalibro_configurations_controller_spec.rb
+++ b/spec/controllers/kalibro_configurations_controller_spec.rb
@@ -89,7 +89,7 @@ describe KalibroConfigurationsController, :type => :controller do
       end
     end
 
-    context 'when an invalid format is requested' do
+    context 'when format requested is not supported' do
       before :each do
         get :show, id: kalibro_configuration.id, format: :txt
       end

--- a/spec/controllers/kalibro_configurations_controller_spec.rb
+++ b/spec/controllers/kalibro_configurations_controller_spec.rb
@@ -70,20 +70,31 @@ describe KalibroConfigurationsController, :type => :controller do
 
   describe 'show' do
     let(:kalibro_configuration) { FactoryGirl.build(:kalibro_configuration, :with_id) }
-    let(:metric_configuration) { FactoryGirl.build(:metric_configuration_with_id) }
 
-    before :each do
-      kalibro_configuration.expects(:tree_metric_configurations).returns([metric_configuration])
-      kalibro_configuration.expects(:hotspot_metric_configurations).returns([])
-      KalibroConfiguration.expects(:find).with(kalibro_configuration.id).returns(kalibro_configuration)
+    context 'when kalibro_configuration is valid' do
+      let(:metric_configuration) { FactoryGirl.build(:metric_configuration_with_id) }
 
-      get :show, :id => kalibro_configuration.id
+      before :each do
+        kalibro_configuration.expects(:tree_metric_configurations).returns([metric_configuration])
+        kalibro_configuration.expects(:hotspot_metric_configurations).returns([])
+        KalibroConfiguration.expects(:find).with(kalibro_configuration.id).returns(kalibro_configuration)
+
+        get :show, :id => kalibro_configuration.id
+      end
+
+      it { is_expected.to render_template(:show) }
+
+      after :each do
+        Rails.cache.clear
+      end
     end
 
-    it { is_expected.to render_template(:show) }
+    context 'when an invalid format is requested' do
+      before :each do
+        get :show, id: kalibro_configuration.id, format: :txt
+      end
 
-    after :each do
-      Rails.cache.clear
+      it { is_expected.to respond_with(:not_acceptable) }
     end
   end
 

--- a/spec/controllers/metric_configurations_controller_spec.rb
+++ b/spec/controllers/metric_configurations_controller_spec.rb
@@ -129,14 +129,28 @@ describe MetricConfigurationsController, :type => :controller do
       end
 
       context 'with valid parameters' do
-        before :each do
-          ReadingGroup.expects(:find).with(metric_configuration.reading_group_id).returns(reading_group)
-          metric_configuration.expects(:kalibro_ranges).returns([kalibro_range])
+        context 'when format requested is supported' do
+          before :each do
+            ReadingGroup.expects(:find).with(metric_configuration.reading_group_id).returns(reading_group)
+            metric_configuration.expects(:kalibro_ranges).returns([kalibro_range])
 
-          get :show, kalibro_configuration_id: metric_configuration.kalibro_configuration_id.to_s, id: metric_configuration.id
+            get :show, kalibro_configuration_id: metric_configuration.kalibro_configuration_id.to_s, id: metric_configuration.id
+          end
+
+          it { is_expected.to render_template(:show) }
         end
 
-        it { is_expected.to render_template(:show) }
+        context 'when format requested is not supported' do
+          before :each do
+            ReadingGroup.expects(:find).with(metric_configuration.reading_group_id).returns(reading_group)
+            metric_configuration.expects(:kalibro_ranges).returns([kalibro_range])
+
+            get :show, kalibro_configuration_id: metric_configuration.kalibro_configuration_id.to_s, id: metric_configuration.id, format: :txt
+          end
+
+          it { is_expected.to respond_with(:not_acceptable) }
+        end
+
       end
 
       context 'with invalid parameters' do

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -75,14 +75,13 @@ describe ProjectsController, :type => :controller do
         it { is_expected.to render_template(:show) }
       end
 
-      context 'when format requested is unknown' do
+      context 'when format requested is not supported' do
         before :each do
           get :show, id: project.id, format: :txt
         end
 
         it { is_expected.to respond_with(:not_acceptable) }
       end
-
     end
 
     context 'when the project does not exists' do
@@ -98,7 +97,7 @@ describe ProjectsController, :type => :controller do
         it { is_expected.to respond_with(:not_found) }
       end
 
-      context 'when the request format is unknown' do
+      context 'when the request format is not supported' do
         before :each do
           get :show, id: project.id, format: :txt
         end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -64,13 +64,25 @@ describe ProjectsController, :type => :controller do
     let(:repository) { FactoryGirl.build(:repository) }
 
     context 'when the project exists' do
-      before :each do
-        Project.expects(:find).with(project.id).returns(project)
-        project.expects(:repositories).returns(repository)
-        get :show, :id => project.id
+
+      context 'when the project is valid' do
+        before :each do
+          Project.expects(:find).with(project.id).returns(project)
+          project.expects(:repositories).returns(repository)
+          get :show, :id => project.id
+        end
+
+        it { is_expected.to render_template(:show) }
       end
 
-      it { is_expected.to render_template(:show) }
+      context 'when format requested is unknown' do
+        before :each do
+          get :show, id: project.id, format: :txt
+        end
+
+        it { is_expected.to respond_with(:not_acceptable) }
+      end
+
     end
 
     context 'when the project does not exists' do

--- a/spec/controllers/reading_groups_controller_spec.rb
+++ b/spec/controllers/reading_groups_controller_spec.rb
@@ -64,13 +64,24 @@ describe ReadingGroupsController, :type => :controller do
 
   describe 'show' do
     let!(:reading_group) { FactoryGirl.build(:reading_group, :with_id) }
-    let(:reading) { FactoryGirl.build(:reading_with_id) }
-    before :each do
-      ReadingGroup.expects(:find).with(reading_group.id).returns(reading_group)
-      get :show, :id => reading_group.id
+
+    context 'when reading group is valid' do
+      let(:reading) { FactoryGirl.build(:reading_with_id) }
+      before :each do
+        ReadingGroup.expects(:find).with(reading_group.id).returns(reading_group)
+        get :show, :id => reading_group.id
+      end
+
+      it { is_expected.to render_template(:show) }
     end
 
-    it { is_expected.to render_template(:show) }
+    context 'when format requested is not supported' do
+      before :each do
+        get :show, id: reading_group.id, format: :txt
+      end
+
+      it { is_expected.to respond_with(:not_acceptable) }
+    end
   end
 
   describe 'destroy' do

--- a/spec/controllers/repositories_controller_spec.rb
+++ b/spec/controllers/repositories_controller_spec.rb
@@ -178,6 +178,14 @@ describe RepositoriesController, :type => :controller do
 
       it { is_expected.to render_template(:show) }
     end
+
+    context 'when format requested is not supported' do
+      before :each do
+        get :show, id: repository.id, format: :txt
+      end
+
+      it { is_expected.to respond_with(:not_acceptable) }
+    end
   end
 
   describe 'destroy' do


### PR DESCRIPTION
- Creating automated tests to simulate unsupported (e.g. text) format requests in kalibro_configurations, metric_configurations, projects, reading_groups and repositories

Closes part of #296